### PR TITLE
Reference actual package required in _grid.scss error

### DIFF
--- a/_grid.scss
+++ b/_grid.scss
@@ -5,7 +5,7 @@
 // We need to check that the GEL settings are available globally
 $gel-settings-available: false !default;
 @if ($gel-settings-available == false) {
-    @warn "Missing Dependency: Have you included the GEL settings?";
+    @warn "Missing Dependency: Have you included the gel-sass-tools?";
 }
 
 

--- a/_grid.scss
+++ b/_grid.scss
@@ -2,7 +2,7 @@
 //    # GEL GRID
 //\*------------------------------------*/
 
-// We need to check that the GEL settings are available globally
+// We need to check that the GEL Sass Tools are available globally
 $gel-settings-available: false !default;
 @if ($gel-settings-available == false) {
     @warn "Missing Dependency: Have you included the gel-sass-tools?";

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "gel-grid",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "homepage": "http://www.bbc.co.uk/gel",
   "authors": [
     "Shaun Bent <shaun.bent@bbc.co.uk>"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gel-grid",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A flexible code implementation of the GEL Grid",
   "main": "_grid.scss",
   "scripts": {


### PR DESCRIPTION
The error message currently causes confusion as `gel-settings` is deprecated and unavailable on npm.