### PR TITLE
Move some of the gel-layout styles into core.css

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "gel-grid",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "homepage": "http://www.bbc.co.uk/gel",
   "authors": [
     "Shaun Bent <shaun.bent@bbc.co.uk>"

--- a/lib/_tools.scss
+++ b/lib/_tools.scss
@@ -58,13 +58,17 @@
 // We want fine-grain control over which implementations of flexbox we support
 // so we will manually handle prefixes
 //
-// 1. Force a single to fill the avaiable space, required for nested grids
-// 2. Remove any margin and padding which may effect our layout
-// 3. Remove any default list styling if the layout is applied to a list
+// 1. Remove any default list styling if the layout is applied to a list
+// 2. Force a single to fill the avaiable space, required for nested grids
+// 3. Remove any margin and padding which may effect our layout
 //
 // @author Shaun Bent
 //
 @mixin gel-layout() {
+    list-style: none; // [1]
+    direction: flip(ltr, rtl);
+    text-align: flip(left, right);
+
     @if $enhanced {
         display: -webkit-flex;
         display: -ms-flexbox;
@@ -72,18 +76,14 @@
         -webkit-flex-flow: row wrap;
         -ms-flex-flow: row wrap;
         flex-flow: row wrap;
-        -webkit-flex: 1 1 auto; // [1]
-        -ms-flex: 1 1 auto; // [1]
-        flex: 1 1 auto; // [1]
+        -webkit-flex: 1 1 auto; // [2]
+        -ms-flex: 1 1 auto; // [2]
+        flex: 1 1 auto; // [2]
 
-        margin-right: 0; // [2]
+        margin-right: 0; // [3]
         margin-left: -$gel-spacing-unit;
-        padding-right: 0; // [2]
-        padding-left: 0; // [2]
-
-        list-style: none; // [3]
-        direction: flip(ltr, rtl);
-        text-align: flip(left, right);
+        padding-right: 0; // [3]
+        padding-left: 0; // [3]
 
         @include mq($from: $gel-grid-gutter-change) {
             margin-left: double(-$gel-spacing-unit);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gel-grid",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A flexible code implementation of the GEL Grid",
   "main": "_grid.scss",
   "scripts": {

--- a/test/test-expected.css
+++ b/test/test-expected.css
@@ -26,6 +26,9 @@
      * A grid row
      */
 .gel-layout {
+  list-style: none;
+  direction: flip(ltr, rtl);
+  text-align: flip(left, right);
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
@@ -39,9 +42,6 @@
   margin-left: -8px;
   padding-right: 0;
   padding-left: 0;
-  list-style: none;
-  direction: flip(ltr, rtl);
-  text-align: flip(left, right);
   letter-spacing: -0.31em;
   text-rendering: optimizespeed;
 }
@@ -1425,6 +1425,9 @@
 }
 
 .my-component {
+  list-style: none;
+  direction: flip(ltr, rtl);
+  text-align: flip(left, right);
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
@@ -1438,9 +1441,6 @@
   margin-left: -8px;
   padding-right: 0;
   padding-left: 0;
-  list-style: none;
-  direction: flip(ltr, rtl);
-  text-align: flip(left, right);
   letter-spacing: -0.31em;
   text-rendering: optimizespeed;
 }


### PR DESCRIPTION
 * `list-style: none` prevents bullet points appearing at larger core widths
 * `direction` and `text-align` ensure that gel-layout--rev works properly on core

![screen shot 2016-08-12 at 10 38 43](https://cloud.githubusercontent.com/assets/794263/17618797/95f22568-6079-11e6-9edf-9f9588253255.png)
