### PR TITLE
Flexbox Fixes

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "gel-grid",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "homepage": "http://www.bbc.co.uk/gel",
   "authors": [
     "Shaun Bent <shaun.bent@bbc.co.uk>"

--- a/demo/src/assets/sass/_component.grid-demo.scss
+++ b/demo/src/assets/sass/_component.grid-demo.scss
@@ -18,10 +18,16 @@
  */
 .gel-c-grid-demo-item {
     width: 100%;
-    height: 48px;
+    padding: $gel-spacing-unit;
 
     background-color: #d4e7eb;
-    background: repeating-linear-gradient(180deg, #d4e7eb, #d4e7eb 8px, #aec4cc 8px, #aec4cc 16px);
+    color: $gel-color--black;
+
+    @if $enhanced {
+        @include mq($from: gel-bp-s) {
+            padding: double($gel-spacing-unit);
+        }
+    }
 }
 
 .gel-c-grid-demo-item--auto {

--- a/demo/src/assets/sass/_component.grid-demo.scss
+++ b/demo/src/assets/sass/_component.grid-demo.scss
@@ -30,6 +30,10 @@
     }
 }
 
+.gel-c-grid-demo-item--fill {
+    background: repeating-linear-gradient(180deg, #d4e7eb, #d4e7eb 8px, #aec4cc 8px, #aec4cc 16px);
+}
+
 .gel-c-grid-demo-item--auto {
     height: auto;
 }

--- a/demo/src/assets/sass/_settings.global.scss
+++ b/demo/src/assets/sass/_settings.global.scss
@@ -10,6 +10,7 @@ $gel-color--white: #fff;
 $gel-color--orange: #e6711b;
 $gel-color--cod-gray: #767676;
 $gel-color--tundora: #404040;
+$gel-color--black: #121212;
 $gel-color--dusty-gray: #ccc;
 $gel-color--alto: #dcdcdc;
 $gel-color--gallery: #f5f5f5;

--- a/demo/src/index.html
+++ b/demo/src/index.html
@@ -279,10 +279,10 @@
 
                 <div class="gel-layout gel-layout--equal gs-u-mt+">
                     <div class="gel-layout__item gel-1/2">
-                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--auto"></div>
+                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--auto gel-c-grid-demo-item--fill"></div>
                     </div><!--
                  --><div class="gel-layout__item gel-1/2">
-                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--large"></div>
+                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--large gel-c-grid-demo-item--fill"></div>
                     </div>
                 </div>
                 <p class="gel-c-grid-demo__summary gel-brevier">Applied with the class: <code>gel-layout--equal</code>. This option only works for browsers which support <code>flexbox</code></p>
@@ -294,14 +294,14 @@
                 <div class="gel-layout gs-u-mt+">
                     <div class="gel-layout__item gel-1/2">
                         <p class="gel-pica gs-u-mb-">Left</p>
-                        <div class="gel-c-grid-demo-item"></div>
+                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
                     </div>
                 </div>
 
                 <div class="gel-layout gel-layout--center gs-u-mt+">
                     <div class="gel-layout__item gel-1/2">
                         <p class="gel-pica gs-u-mb-">Centre</p>
-                        <div class="gel-c-grid-demo-item"></div>
+                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
                         <p class="gel-c-grid-demo__summary gel-brevier">Applied with the class: <code>gel-layout--center</code></p>
                     </div>
                 </div>
@@ -309,7 +309,7 @@
                 <div class="gel-layout gel-layout--right gs-u-mt+">
                     <div class="gel-layout__item gel-1/2">
                         <p class="gel-pica gs-u-mb-">Right</p>
-                        <div class="gel-c-grid-demo-item"></div>
+                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
                         <p class="gel-c-grid-demo__summary gel-brevier">Applied with the class: <code>gel-layout--right</code></p>
                     </div>
                 </div>
@@ -320,13 +320,13 @@
 
                 <div class="gel-layout gs-u-mt+">
                     <div class="gel-layout__item gel-1/3">
-                        <div class="gel-c-grid-demo-item"></div>
+                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
                     </div><!--
                  --><div class="gel-layout__item gel-1/3">
-                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--large"></div>
+                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--large gel-c-grid-demo-item--fill"></div>
                     </div><!--
                  --><div class="gel-layout__item gel-1/3">
-                        <div class="gel-c-grid-demo-item"></div>
+                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
                     </div>
                 </div>
             </div>
@@ -336,13 +336,13 @@
 
                 <div class="gel-layout gel-layout--middle gs-u-mt+">
                     <div class="gel-layout__item gel-1/3">
-                        <div class="gel-c-grid-demo-item"></div>
+                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
                     </div><!--
                  --><div class="gel-layout__item gel-1/3">
-                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--large"></div>
+                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--large gel-c-grid-demo-item--fill"></div>
                     </div><!--
                  --><div class="gel-layout__item gel-1/3">
-                        <div class="gel-c-grid-demo-item"></div>
+                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
                     </div>
                 </div>
                 <p class="gel-c-grid-demo__summary gel-brevier">Applied with the class: <code>gel-layout--middle</code></p>
@@ -353,13 +353,13 @@
 
                 <div class="gel-layout gel-layout--bottom gs-u-mt+">
                     <div class="gel-layout__item gel-1/3">
-                        <div class="gel-c-grid-demo-item"></div>
+                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
                     </div><!--
                  --><div class="gel-layout__item gel-1/3">
-                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--large"></div>
+                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--large gel-c-grid-demo-item--fill"></div>
                     </div><!--
                  --><div class="gel-layout__item gel-1/3">
-                        <div class="gel-c-grid-demo-item"></div>
+                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
                     </div>
                 </div>
                 <p class="gel-c-grid-demo__summary gel-brevier">Applied with the class: <code>gel-layout--bottom</code></p>
@@ -371,19 +371,19 @@
                 <div class="gel-layout gel-layout--rev gs-u-mt+">
                     <div class="gel-layout__item gel-1/4">
                         <p class="gel-pica gs-u-mb-">1</p>
-                        <div class="gel-c-grid-demo-item"></div>
+                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
                     </div><!--
                  --><div class="gel-layout__item gel-1/4">
                         <p class="gel-pica gs-u-mb-">2</p>
-                        <div class="gel-c-grid-demo-item"></div>
+                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
                     </div><!--
                  --><div class="gel-layout__item gel-1/4">
                         <p class="gel-pica gs-u-mb-">3</p>
-                        <div class="gel-c-grid-demo-item"></div>
+                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
                     </div><!--
                  --><div class="gel-layout__item gel-1/4">
                         <p class="gel-pica gs-u-mb-">4</p>
-                        <div class="gel-c-grid-demo-item"></div>
+                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
                     </div>
                 </div>
                 <p class="gel-c-grid-demo__summary gel-brevier">Applied with the class: <code>gel-layout--rev</code></p>
@@ -394,19 +394,19 @@
 
                 <div class="gel-layout gs-u-mt+">
                     <div class="gel-layout__item gel-layout__item--top gel-1/4">
-                        <div class="gel-c-grid-demo-item"></div>
+                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
                         <p class="gel-brevier gs-u-mt-">Align Top</p>
                     </div><!--
                  --><div class="gel-layout__item gel-1/4">
-                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--large"></div>
+                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--large gel-c-grid-demo-item--fill"></div>
                     </div><!--
                  --><div class="gel-layout__item gel-layout__item--center gel-1/4">
-                        <div class="gel-c-grid-demo-item"></div>
+                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
                         <p class="gel-brevier gs-u-mt-">Align Center</p>
                     </div><!--
                  --><div class="gel-layout__item gel-layout__item--bottom gel-1/4">
                         <p class="gel-brevier gs-u-mb-">Align Bottom</p>
-                        <div class="gel-c-grid-demo-item"></div>
+                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
                     </div>
                 </div>
                 <p class="gel-c-grid-demo__summary gel-brevier">Applied with classes on individual layout items: <code>gel-layout__item--top</code>, <code>gel-layout__item--center</code>, <code>gel-layout__item--bottom</code></p>
@@ -418,19 +418,19 @@
                 <div class="gel-layout gel-layout--flush gs-u-mt+">
                     <div class="gel-layout__item gel-1/4">
                         <p class="gel-pica gs-u-mb-">1</p>
-                        <div class="gel-c-grid-demo-item"></div>
+                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
                     </div><!--
                  --><div class="gel-layout__item gel-1/4">
                         <p class="gel-pica gs-u-mb-">2</p>
-                        <div class="gel-c-grid-demo-item"></div>
+                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
                     </div><!--
                  --><div class="gel-layout__item gel-1/4">
                         <p class="gel-pica gs-u-mb-">3</p>
-                        <div class="gel-c-grid-demo-item"></div>
+                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
                     </div><!--
                  --><div class="gel-layout__item gel-1/4">
                         <p class="gel-pica gs-u-mb-">4</p>
-                        <div class="gel-c-grid-demo-item"></div>
+                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
                     </div>
                 </div>
                 <p class="gel-c-grid-demo__summary gel-brevier">Applied with the class: <code>gel-layout--flush</code></p>
@@ -442,29 +442,29 @@
                 <div class="gel-layout gel-layout--fit gs-u-mt+">
                     <div class="gel-layout__item">
                         <p class="gel-pica gs-u-mb-">1</p>
-                        <div class="gel-c-grid-demo-item"></div>
+                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
                     </div><!--
                  --><div class="gel-layout__item">
                         <p class="gel-pica gs-u-mb-">2</p>
-                        <div class="gel-c-grid-demo-item"></div>
+                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
                     </div><!--
                  --><div class="gel-layout__item">
                         <p class="gel-pica gs-u-mb-">3</p>
-                        <div class="gel-c-grid-demo-item"></div>
+                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
                     </div><!--
                  --><div class="gel-layout__item">
                         <p class="gel-pica gs-u-mb-">4</p>
-                        <div class="gel-c-grid-demo-item"></div>
+                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
                     </div>
                 </div>
                 <div class="gel-layout gel-layout--fit gs-u-mt+">
                     <div class="gel-layout__item">
                         <p class="gel-pica gs-u-mb-">1</p>
-                        <div class="gel-c-grid-demo-item"></div>
+                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
                     </div><!--
                  --><div class="gel-layout__item">
                         <p class="gel-pica gs-u-mb-">2</p>
-                        <div class="gel-c-grid-demo-item"></div>
+                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
                     </div>
                 </div>
                 <p class="gel-c-grid-demo__summary gel-brevier">Applied with the class: <code>gel-layout--fit</code>. This option only works for browsers which support <code>flexbox</code></p>

--- a/demo/src/index.html
+++ b/demo/src/index.html
@@ -80,106 +80,88 @@
 
                 <div class="gel-layout gs-u-mt+">
                     <div class="gel-layout__item">
-                        <p class="gel-pica gs-u-mb">100% (Whole)</p>
-                    </div><!--
-                 --><div class="gel-layout__item">
-                        <div class="gel-c-grid-demo-item"></div>
+                        <div class="gel-c-grid-demo-item">100%</div>
                     </div>
                 </div>
 
                 <div class="gel-layout gs-u-mt+">
-                    <div class="gel-layout__item">
-                        <p class="gel-pica gs-u-mb">50% (Halves)</p>
+                    <div class="gel-layout__item gel-1/2">
+                        <div class="gel-c-grid-demo-item">50%</div>
                     </div><!--
                  --><div class="gel-layout__item gel-1/2">
-                        <div class="gel-c-grid-demo-item"></div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/2">
-                        <div class="gel-c-grid-demo-item"></div>
+                        <div class="gel-c-grid-demo-item">50%</div>
                     </div>
                 </div>
 
                 <div class="gel-layout gs-u-mt+">
-                    <div class="gel-layout__item">
-                        <p class="gel-pica gs-u-mb">33.333% (Thirds)</p>
+                    <div class="gel-layout__item gel-1/3">
+                        <div class="gel-c-grid-demo-item">33.333%</div>
                     </div><!--
                  --><div class="gel-layout__item gel-1/3">
-                        <div class="gel-c-grid-demo-item"></div>
+                        <div class="gel-c-grid-demo-item">33.333%</div>
                     </div><!--
                  --><div class="gel-layout__item gel-1/3">
-                        <div class="gel-c-grid-demo-item"></div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/3">
-                        <div class="gel-c-grid-demo-item"></div>
+                        <div class="gel-c-grid-demo-item">33.333%</div>
                     </div>
                 </div>
 
                 <div class="gel-layout gs-u-mt+">
-                    <div class="gel-layout__item">
-                        <p class="gel-pica gs-u-mb">25% (Quarters)</p>
+                    <div class="gel-layout__item gel-1/4">
+                        <div class="gel-c-grid-demo-item">25%</div>
                     </div><!--
                  --><div class="gel-layout__item gel-1/4">
-                        <div class="gel-c-grid-demo-item"></div>
+                        <div class="gel-c-grid-demo-item">25%</div>
                     </div><!--
                  --><div class="gel-layout__item gel-1/4">
-                        <div class="gel-c-grid-demo-item"></div>
+                        <div class="gel-c-grid-demo-item">25%</div>
                     </div><!--
                  --><div class="gel-layout__item gel-1/4">
-                        <div class="gel-c-grid-demo-item"></div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/4">
-                        <div class="gel-c-grid-demo-item"></div>
+                        <div class="gel-c-grid-demo-item">25%</div>
                     </div>
                 </div>
 
                 <div class="gel-layout gs-u-mt+">
-                    <div class="gel-layout__item">
-                        <p class="gel-pica gs-u-mb">20% (Fifths)</p>
+                    <div class="gel-layout__item gel-1/5">
+                        <div class="gel-c-grid-demo-item">20%</div>
                     </div><!--
                  --><div class="gel-layout__item gel-1/5">
-                        <div class="gel-c-grid-demo-item"></div>
+                        <div class="gel-c-grid-demo-item">20%</div>
                     </div><!--
                  --><div class="gel-layout__item gel-1/5">
-                        <div class="gel-c-grid-demo-item"></div>
+                        <div class="gel-c-grid-demo-item">20%</div>
                     </div><!--
                  --><div class="gel-layout__item gel-1/5">
-                        <div class="gel-c-grid-demo-item"></div>
+                        <div class="gel-c-grid-demo-item">20%</div>
                     </div><!--
                  --><div class="gel-layout__item gel-1/5">
-                        <div class="gel-c-grid-demo-item"></div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/5">
-                        <div class="gel-c-grid-demo-item"></div>
+                        <div class="gel-c-grid-demo-item">20%</div>
                     </div>
                 </div>
 
                 <div class="gel-layout gs-u-mt+">
-                    <div class="gel-layout__item">
-                        <p class="gel-pica gs-u-mb">12.5% (Eighths)</p>
+                    <div class="gel-layout__item gel-1/8">
+                        <div class="gel-c-grid-demo-item">12.5%</div>
                     </div><!--
                  --><div class="gel-layout__item gel-1/8">
-                        <div class="gel-c-grid-demo-item"></div>
+                        <div class="gel-c-grid-demo-item">12.5%</div>
                     </div><!--
                  --><div class="gel-layout__item gel-1/8">
-                        <div class="gel-c-grid-demo-item"></div>
+                        <div class="gel-c-grid-demo-item">12.5%</div>
                     </div><!--
                  --><div class="gel-layout__item gel-1/8">
-                        <div class="gel-c-grid-demo-item"></div>
+                        <div class="gel-c-grid-demo-item">12.5%</div>
                     </div><!--
                  --><div class="gel-layout__item gel-1/8">
-                        <div class="gel-c-grid-demo-item"></div>
+                        <div class="gel-c-grid-demo-item">12.5%</div>
                     </div><!--
                  --><div class="gel-layout__item gel-1/8">
-                        <div class="gel-c-grid-demo-item"></div>
+                        <div class="gel-c-grid-demo-item">12.5%</div>
                     </div><!--
                  --><div class="gel-layout__item gel-1/8">
-                        <div class="gel-c-grid-demo-item"></div>
+                        <div class="gel-c-grid-demo-item">12.5%</div>
                     </div><!--
                  --><div class="gel-layout__item gel-1/8">
-                        <div class="gel-c-grid-demo-item"></div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/8">
-                        <div class="gel-c-grid-demo-item"></div>
+                        <div class="gel-c-grid-demo-item">12.5%</div>
                     </div>
                 </div>
             </div>
@@ -192,10 +174,10 @@
                         <p class="gel-pica gs-u-mb">Quarter / Three Quarters</p>
                     </div><!--
                  --><div class="gel-layout__item gel-1/4@xs">
-                        <div class="gel-c-grid-demo-item"></div>
+                        <div class="gel-c-grid-demo-item">25%</div>
                     </div><!--
                  --><div class="gel-layout__item gel-3/4@xs">
-                        <div class="gel-c-grid-demo-item"></div>
+                        <div class="gel-c-grid-demo-item">75%</div>
                     </div>
                 </div>
                 <p class="gel-c-grid-demo__summary gel-brevier">Applied at extra small (240px) devices and above.</p>
@@ -205,16 +187,16 @@
                         <p class="gel-pica gs-u-mb">Half / Quarter / Two Eighths</p>
                     </div><!--
                  --><div class="gel-layout__item gel-1/2@s">
-                        <div class="gel-c-grid-demo-item"></div>
+                        <div class="gel-c-grid-demo-item">50%</div>
                     </div><!--
                  --><div class="gel-layout__item gel-1/4@s">
-                        <div class="gel-c-grid-demo-item"></div>
+                        <div class="gel-c-grid-demo-item">25%</div>
                     </div><!--
                  --><div class="gel-layout__item gel-1/8@s">
-                        <div class="gel-c-grid-demo-item"></div>
+                        <div class="gel-c-grid-demo-item">12.5%</div>
                     </div><!--
                  --><div class="gel-layout__item gel-1/8@s">
-                        <div class="gel-c-grid-demo-item"></div>
+                        <div class="gel-c-grid-demo-item">12.5%</div>
                     </div>
                 </div>
                 <p class="gel-c-grid-demo__summary gel-brevier">Applied at small (400px) devices and above.</p>
@@ -224,10 +206,10 @@
                         <p class="gel-pica gs-u-mb">Two Thirds / Third</p>
                     </div><!--
                  --><div class="gel-layout__item gel-2/3@m">
-                        <div class="gel-c-grid-demo-item"></div>
+                        <div class="gel-c-grid-demo-item">66.666%</div>
                     </div><!--
                  --><div class="gel-layout__item gel-1/3@m">
-                        <div class="gel-c-grid-demo-item"></div>
+                        <div class="gel-c-grid-demo-item">33.333%</div>
                     </div>
                 </div>
                 <p class="gel-c-grid-demo__summary gel-brevier">Applied at medium (600px) devices and above.</p>
@@ -237,18 +219,18 @@
                         <p class="gel-pica gs-u-mb">Half / Three Sixths</p>
                     </div><!--
                  --><div class="gel-layout__item gel-1/2@l">
-                        <div class="gel-c-grid-demo-item"></div>
+                        <div class="gel-c-grid-demo-item">50%</div>
                     </div><!--
                  --><div class="gel-layout__item gel-1/2@l">
                         <div class="gel-layout gs-u-mt+ gs-u-mt0@l">
                            <div class="gel-layout__item gel-1/3@s">
-                               <div class="gel-c-grid-demo-item"></div>
+                               <div class="gel-c-grid-demo-item">33.333%</div>
                            </div><!--
                         --><div class="gel-layout__item gel-1/3@s">
-                               <div class="gel-c-grid-demo-item"></div>
+                               <div class="gel-c-grid-demo-item">33.333%</div>
                            </div><!--
                         --><div class="gel-layout__item gel-1/3@s">
-                               <div class="gel-c-grid-demo-item"></div>
+                               <div class="gel-c-grid-demo-item">33.333%</div>
                            </div>
                         </div>
                     </div>
@@ -260,30 +242,30 @@
                 <h2 class="gel-double-pica-bold">Nested Grids</h2>
 
                 <div class="gel-layout gel-layout--equal gs-u-mt+">
-                    <div class="gel-layout__item gel-1/2">
-                        <div class="gel-c-grid-demo-item gel-pica"></div>
+                    <div class="gel-layout__item gel-1/2@m">
+                        <div class="gel-c-grid-demo-item gel-pica">50%</div>
                     </div><!--
-                 --><div class="gel-layout__item gel-1/2">
+                 --><div class="gel-layout__item gel-1/2@m">
                         <div class="gel-layout">
-                            <div class="gel-layout__item gel-1/3">
-                                <div class="gel-c-grid-demo-item gel-pica"></div>
+                            <div class="gel-layout__item gel-1/3@s">
+                                <div class="gel-c-grid-demo-item gel-pica">33.333%</div>
                             </div><!--
-                         --><div class="gel-layout__item gel-2/3">
+                         --><div class="gel-layout__item gel-2/3@s">
                                 <div class="gel-layout">
                                     <div class="gel-layout__item gel-1/2">
-                                        <div class="gel-c-grid-demo-item gel-pica"></div>
+                                        <div class="gel-c-grid-demo-item gel-pica">50%</div>
                                     </div><!--
                                  --><div class="gel-layout__item gel-1/2">
-                                        <div class="gel-c-grid-demo-item gel-pica"></div>
+                                        <div class="gel-c-grid-demo-item gel-pica">50%</div>
                                     </div><!--
                                  --><div class="gel-layout__item gel-1/3">
-                                        <div class="gel-c-grid-demo-item gel-pica"></div>
+                                        <div class="gel-c-grid-demo-item gel-pica">33.333%</div>
                                     </div><!--
                                  --><div class="gel-layout__item gel-1/3">
-                                        <div class="gel-c-grid-demo-item gel-pica"></div>
+                                        <div class="gel-c-grid-demo-item gel-pica">33.333%</div>
                                     </div><!--
                                  --><div class="gel-layout__item gel-1/3">
-                                        <div class="gel-c-grid-demo-item gel-pica"></div>
+                                        <div class="gel-c-grid-demo-item gel-pica">33.333%</div>
                                     </div>
                                 </div>
                             </div>

--- a/demo/src/index.html
+++ b/demo/src/index.html
@@ -256,6 +256,42 @@
                 <p class="gel-c-grid-demo__summary gel-brevier">Applied at large (900px) devices and above.</p>
             </div>
 
+            <div class="gel-c-grid-demo-section" id="nested-grids">
+                <h2 class="gel-double-pica-bold">Nested Grids</h2>
+
+                <div class="gel-layout gel-layout--equal gs-u-mt+">
+                    <div class="gel-layout__item gel-1/2">
+                        <div class="gel-c-grid-demo-item gel-pica">50%</div>
+                    </div><!--
+                 --><div class="gel-layout__item gel-1/2">
+                        <div class="gel-layout">
+                            <div class="gel-layout__item gel-1/3">
+                                <div class="gel-c-grid-demo-item gel-pica">33.33333%</div>
+                            </div><!--
+                         --><div class="gel-layout__item gel-2/3">
+                                <div class="gel-layout">
+                                    <div class="gel-layout__item gel-1/2">
+                                        <div class="gel-c-grid-demo-item gel-pica">50%</div>
+                                    </div><!--
+                                 --><div class="gel-layout__item gel-1/2">
+                                        <div class="gel-c-grid-demo-item gel-pica">50%</div>
+                                    </div><!--
+                                 --><div class="gel-layout__item gel-1/3">
+                                        <div class="gel-c-grid-demo-item gel-pica">33.33333%</div>
+                                    </div><!--
+                                 --><div class="gel-layout__item gel-1/3">
+                                        <div class="gel-c-grid-demo-item gel-pica">33.33333%</div>
+                                    </div><!--
+                                 --><div class="gel-layout__item gel-1/3">
+                                        <div class="gel-c-grid-demo-item gel-pica">33.33333%</div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
             <div class="gel-c-grid-demo-section" id="equal-height">
                 <h2 class="gel-double-pica-bold">Equal Height</h2>
 

--- a/demo/src/index.html
+++ b/demo/src/index.html
@@ -261,29 +261,29 @@
 
                 <div class="gel-layout gel-layout--equal gs-u-mt+">
                     <div class="gel-layout__item gel-1/2">
-                        <div class="gel-c-grid-demo-item gel-pica">50%</div>
+                        <div class="gel-c-grid-demo-item gel-pica"></div>
                     </div><!--
                  --><div class="gel-layout__item gel-1/2">
                         <div class="gel-layout">
                             <div class="gel-layout__item gel-1/3">
-                                <div class="gel-c-grid-demo-item gel-pica">33.33333%</div>
+                                <div class="gel-c-grid-demo-item gel-pica"></div>
                             </div><!--
                          --><div class="gel-layout__item gel-2/3">
                                 <div class="gel-layout">
                                     <div class="gel-layout__item gel-1/2">
-                                        <div class="gel-c-grid-demo-item gel-pica">50%</div>
+                                        <div class="gel-c-grid-demo-item gel-pica"></div>
                                     </div><!--
                                  --><div class="gel-layout__item gel-1/2">
-                                        <div class="gel-c-grid-demo-item gel-pica">50%</div>
+                                        <div class="gel-c-grid-demo-item gel-pica"></div>
                                     </div><!--
                                  --><div class="gel-layout__item gel-1/3">
-                                        <div class="gel-c-grid-demo-item gel-pica">33.33333%</div>
+                                        <div class="gel-c-grid-demo-item gel-pica"></div>
                                     </div><!--
                                  --><div class="gel-layout__item gel-1/3">
-                                        <div class="gel-c-grid-demo-item gel-pica">33.33333%</div>
+                                        <div class="gel-c-grid-demo-item gel-pica"></div>
                                     </div><!--
                                  --><div class="gel-layout__item gel-1/3">
-                                        <div class="gel-c-grid-demo-item gel-pica">33.33333%</div>
+                                        <div class="gel-c-grid-demo-item gel-pica"></div>
                                     </div>
                                 </div>
                             </div>

--- a/lib/_tools.scss
+++ b/lib/_tools.scss
@@ -104,10 +104,9 @@
 // A single layout group/row, this wraps individual layout items
 //
 // 1. Cause columns to stack side-by-side
-// 2. Items shouldn't grow or shrink in size
-// 3. Space columns apart
-// 4. Ensure all text is aligned correctly
-// 5. Align columns to the tops of each other
+// 2. Space columns apart
+// 3. Ensure all text is aligned correctly
+// 4. Align columns to the tops of each other
 //
 // @author  Shaun Bent
 //
@@ -115,16 +114,13 @@
     @if $enhanced {
         width: 100%;
         display: inline-block; // [1]
-        -webkit-flex: 0 0 auto; // [2]
-        -ms-flex: 0 0 auto; // [2]
-        flex: 0 0 auto; // [2]
-        padding-left: $gel-spacing-unit; // [3]
+        padding-left: $gel-spacing-unit; // [2]
 
-        text-align: flip(left, right); // [4]
-        vertical-align: top; // [5]
+        text-align: flip(left, right); // [3]
+        vertical-align: top; // [4]
 
         @include mq($from: $gel-grid-gutter-change) {
-            padding-left: double($gel-spacing-unit); // [3]
+            padding-left: double($gel-spacing-unit); // [2]
         }
 
         @if $gel-grid-enable--box-sizing {

--- a/lib/_tools.scss
+++ b/lib/_tools.scss
@@ -266,29 +266,6 @@
     }
 
     /**
-     * Force items to be of equal height
-     */
-    .#{$gel-grid-namespace}layout--equal {
-        > .#{$gel-grid-namespace}layout__item {
-            display: -webkit-flex;
-            display: -ms-flexbox;
-            display: flex;
-        }
-    }
-
-    /**
-     * Allow items to devide the space equally between the number of items
-     */
-    .#{$gel-grid-namespace}layout--fit {
-        > .#{$gel-grid-namespace}layout__item {
-            width: auto;
-            -webkit-flex: 1 1 auto;
-            -ms-flex: 1 1 auto;
-            flex: 1 1 auto;
-        }
-    }
-
-    /**
      * Disable the flexbox grid
      */
     .#{$gel-grid-namespace}layout--no-flex {
@@ -298,31 +275,57 @@
         }
     }
 
-    /**
-     * Align a single grid item to the top
-     */
-    .#{$gel-grid-namespace}layout__item--top {
-        -webkit-align-self: flex-start;
-        -ms-flex-item-align: start;
-        align-self: flex-start;
-    }
+    @if $enhanced {
 
-    /**
-     * Align a single grid item to the center
-     */
-    .#{$gel-grid-namespace}layout__item--center {
-        -webkit-align-self: center;
-        -ms-flex-item-align: center;
-        align-self: center;
-    }
+        /**
+         * Force items to be of equal height
+         */
+        .#{$gel-grid-namespace}layout--equal {
+            > .#{$gel-grid-namespace}layout__item {
+                display: -webkit-flex;
+                display: -ms-flexbox;
+                display: flex;
+            }
+        }
 
-    /**
-     * Align a single grid item to the bottom
-     */
-    .#{$gel-grid-namespace}layout__item--bottom {
-        -webkit-align-self: flex-end;
-        -ms-flex-item-align: end;
-        align-self: flex-end;
+        /**
+         * Allow items to devide the space equally between the number of items
+         */
+        .#{$gel-grid-namespace}layout--fit {
+            > .#{$gel-grid-namespace}layout__item {
+                width: auto;
+                -webkit-flex: 1 1 auto;
+                -ms-flex: 1 1 auto;
+                flex: 1 1 auto;
+            }
+        }
+
+        /**
+         * Align a single grid item to the top
+         */
+        .#{$gel-grid-namespace}layout__item--top {
+            -webkit-align-self: flex-start;
+            -ms-flex-item-align: start;
+            align-self: flex-start;
+        }
+
+        /**
+         * Align a single grid item to the center
+         */
+        .#{$gel-grid-namespace}layout__item--center {
+            -webkit-align-self: center;
+            -ms-flex-item-align: center;
+            align-self: center;
+        }
+
+        /**
+         * Align a single grid item to the bottom
+         */
+        .#{$gel-grid-namespace}layout__item--bottom {
+            -webkit-align-self: flex-end;
+            -ms-flex-item-align: end;
+            align-self: flex-end;
+        }
     }
 }
 

--- a/lib/_tools.scss
+++ b/lib/_tools.scss
@@ -58,13 +58,16 @@
 // We want fine-grain control over which implementations of flexbox we support
 // so we will manually handle prefixes
 //
-// 1. Force a single to fill the avaiable space, required for nested grids
+// 1. Remove any default list styling if the layout is applied to a list
 // 2. Remove any margin and padding which may effect our layout
-// 3. Remove any default list styling if the layout is applied to a list
 //
 // @author Shaun Bent
 //
 @mixin gel-layout() {
+    list-style: none; // [1]
+    direction: flip(ltr, rtl);
+    text-align: flip(left, right);
+
     @if $enhanced {
         display: -webkit-flex;
         display: -ms-flexbox;
@@ -72,18 +75,11 @@
         -webkit-flex-flow: row wrap;
         -ms-flex-flow: row wrap;
         flex-flow: row wrap;
-        -webkit-flex: 1 1 auto; // [1]
-        -ms-flex: 1 1 auto; // [1]
-        flex: 1 1 auto; // [1]
 
         margin-right: 0; // [2]
         margin-left: -$gel-spacing-unit;
         padding-right: 0; // [2]
         padding-left: 0; // [2]
-
-        list-style: none; // [3]
-        direction: flip(ltr, rtl);
-        text-align: flip(left, right);
 
         @include mq($from: $gel-grid-gutter-change) {
             margin-left: double(-$gel-spacing-unit);
@@ -109,9 +105,10 @@
 // A single layout group/row, this wraps individual layout items
 //
 // 1. Cause columns to stack side-by-side
-// 2. Space columns apart
-// 3. Ensure all text is aligned correctly
-// 4. Align columns to the tops of each other
+// 2. Items shouldn't grow or shrink in size
+// 3. Space columns apart
+// 4. Ensure all text is aligned correctly
+// 5. Align columns to the tops of each other
 //
 // @author  Shaun Bent
 //
@@ -119,13 +116,16 @@
     @if $enhanced {
         width: 100%;
         display: inline-block; // [1]
-        padding-left: $gel-spacing-unit; // [2]
+        -webkit-flex: 0 0 auto; // [2]
+        -ms-flex: 0 0 auto; // [2]
+        flex: 0 0 auto; // [2]
+        padding-left: $gel-spacing-unit; // [3]
 
-        text-align: flip(left, right); // [3]
-        vertical-align: top; // [4]
+        text-align: flip(left, right); // [4]
+        vertical-align: top; // [5]
 
         @include mq($from: $gel-grid-gutter-change) {
-            padding-left: double($gel-spacing-unit); // [2]
+            padding-left: double($gel-spacing-unit); // [3]
         }
 
         @if $gel-grid-enable--box-sizing {
@@ -274,9 +274,6 @@
             display: -webkit-flex;
             display: -ms-flexbox;
             display: flex;
-            -webkit-flex-flow: row wrap;
-            -ms-flex-flow: row wrap;
-            flex-flow: row wrap;
         }
     }
 
@@ -296,7 +293,10 @@
      * Disable the flexbox grid
      */
     .#{$gel-grid-namespace}layout--no-flex {
-        display: initial;
+        &,
+        > .#{$gel-grid-namespace}layout__item {
+            display: initial;
+        }
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gel-grid",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "A flexible code implementation of the GEL Grid",
   "main": "_grid.scss",
   "scripts": {

--- a/test/test-expected.css
+++ b/test/test-expected.css
@@ -35,9 +35,6 @@
   -webkit-flex-flow: row wrap;
   -ms-flex-flow: row wrap;
   flex-flow: row wrap;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
   margin-right: 0;
   margin-left: -8px;
   padding-right: 0;
@@ -63,6 +60,9 @@
 .gel-layout__item {
   width: 100%;
   display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
   padding-left: 8px;
   text-align: flip(left, right);
   vertical-align: top;
@@ -175,20 +175,25 @@
 }
 
 /**
-     * Force items to be of equal height
+     * Disable the flexbox grid
      */
+.gel-layout--no-flex,
+.gel-layout--no-flex > .gel-layout__item {
+  display: block;
+}
+
+/**
+         * Force items to be of equal height
+         */
 .gel-layout--equal > .gel-layout__item {
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex-flow: row wrap;
-  -ms-flex-flow: row wrap;
-  flex-flow: row wrap;
 }
 
 /**
-     * Allow items to devide the space equally between the number of items
-     */
+         * Allow items to devide the space equally between the number of items
+         */
 .gel-layout--fit > .gel-layout__item {
   width: auto;
   -webkit-flex: 1 1 auto;
@@ -197,15 +202,8 @@
 }
 
 /**
-     * Disable the flexbox grid
-     */
-.gel-layout--no-flex {
-  display: block;
-}
-
-/**
-     * Align a single grid item to the top
-     */
+         * Align a single grid item to the top
+         */
 .gel-layout__item--top {
   -webkit-align-self: flex-start;
   -ms-flex-item-align: start;
@@ -213,8 +211,8 @@
 }
 
 /**
-     * Align a single grid item to the center
-     */
+         * Align a single grid item to the center
+         */
 .gel-layout__item--center {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
@@ -222,8 +220,8 @@
 }
 
 /**
-     * Align a single grid item to the bottom
-     */
+         * Align a single grid item to the bottom
+         */
 .gel-layout__item--bottom {
   -webkit-align-self: flex-end;
   -ms-flex-item-align: end;
@@ -1434,9 +1432,6 @@
   -webkit-flex-flow: row wrap;
   -ms-flex-flow: row wrap;
   flex-flow: row wrap;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
   margin-right: 0;
   margin-left: -8px;
   padding-right: 0;
@@ -1459,6 +1454,9 @@
 .my-component__item {
   width: 100%;
   display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
   padding-left: 8px;
   text-align: flip(left, right);
   vertical-align: top;

--- a/test/test-expected.css
+++ b/test/test-expected.css
@@ -60,9 +60,6 @@
 .gel-layout__item {
   width: 100%;
   display: inline-block;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
   padding-left: 8px;
   text-align: flip(left, right);
   vertical-align: top;
@@ -1454,9 +1451,6 @@
 .my-component__item {
   width: 100%;
   display: inline-block;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
   padding-left: 8px;
   text-align: flip(left, right);
   vertical-align: top;


### PR DESCRIPTION
**Update**

Turned out the issue that was holding us up here was the result of me having empty demo elements and not actually an issue with the grid itself.

So things done in this PR:

- [x] Remove `flex` styles from `.gel-layout` as this caused issues with nested grids of equal height
- [x] Add `.gel-layout--no-flex` class so we can remove flexbox styling
- [x] Nest the flexbox features within an `@if $enhanced` block to stop them from being output to core users
- [x] Update the demo

**Old Notes**
> @wildlyinaccurate @mintuz @greenc05 - I've been investigating what is wrong with the grid and here are my findings. I'm off this next week so pushing this up so you can take over investigating this one.
> 
> I think we go something wrong with the grid as nested grids don't seem to work properly.
> 
> I've gone back to my orginal Codepen and added a nested grid example and with a few tweaks I've managed to get it working: http://codepen.io/shaunbent/pen/obrBxb?editors=1100
>
> I've ported this implementation across to the Grid and it behaves differently: http://bbc.github.io/gel-grid/#nested-grids
>
> I can't see any difference in the implementation myself but I've pushed it up here so you can take a look.