### PR TITLE
Use display: block for --no-flex layouts

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "gel-grid",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "homepage": "http://www.bbc.co.uk/gel",
   "authors": [
     "Shaun Bent <shaun.bent@bbc.co.uk>"

--- a/lib/_tools.scss
+++ b/lib/_tools.scss
@@ -296,7 +296,7 @@
      * Disable the flexbox grid
      */
     .#{$gel-grid-namespace}layout--no-flex {
-        display: initial;
+        display: block;
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gel-grid",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "A flexible code implementation of the GEL Grid",
   "main": "_grid.scss",
   "scripts": {

--- a/test/test-expected.css
+++ b/test/test-expected.css
@@ -200,7 +200,7 @@
      * Disable the flexbox grid
      */
 .gel-layout--no-flex {
-  display: initial;
+  display: block;
 }
 
 /**


### PR DESCRIPTION
We found out that `display: initial` === `display: inline`, which causes the --no-flex grids to render strangely in some cases.