### PR TITLE
Gel Grid - No flex - Add different styles for core and enhanced

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "gel-grid",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "homepage": "http://www.bbc.co.uk/gel",
   "authors": [
     "Shaun Bent <shaun.bent@bbc.co.uk>"

--- a/lib/_tools.scss
+++ b/lib/_tools.scss
@@ -267,10 +267,10 @@
     .#{$gel-grid-namespace}layout--no-flex {
         &,
         > .#{$gel-grid-namespace}layout__item {
-            display: inline-block;
+            display: block;
 
             @if $enhanced {
-                display: block;
+                display: inline-block;
             }
         }
     }

--- a/lib/_tools.scss
+++ b/lib/_tools.scss
@@ -262,16 +262,26 @@
     }
 
     /**
-     * Disable the flexbox grid
+     * Disable the flexbox grid on core with display block
      */
     .#{$gel-grid-namespace}layout--no-flex {
         &,
         > .#{$gel-grid-namespace}layout__item {
-            display: inline-block;
+            display: block;
         }
     }
 
     @if $enhanced {
+    
+        /**
+        * Disable the flexbox grid on enhanced with display inline-block
+        */
+        .#{$gel-grid-namespace}layout--no-flex {
+            &,
+            > .#{$gel-grid-namespace}layout__item {
+                display: inline-block;
+            }
+        }
 
         /**
          * Force items to be of equal height

--- a/lib/_tools.scss
+++ b/lib/_tools.scss
@@ -262,26 +262,20 @@
     }
 
     /**
-     * Disable the flexbox grid on core with display block
+     * Disable the flexbox grid
      */
     .#{$gel-grid-namespace}layout--no-flex {
         &,
         > .#{$gel-grid-namespace}layout__item {
-            display: block;
+            display: inline-block;
+
+            @if $enhanced {
+                display: block;
+            }
         }
     }
 
     @if $enhanced {
-    
-        /**
-        * Disable the flexbox grid on enhanced with display inline-block
-        */
-        .#{$gel-grid-namespace}layout--no-flex {
-            &,
-            > .#{$gel-grid-namespace}layout__item {
-                display: inline-block;
-            }
-        }
 
         /**
          * Force items to be of equal height

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gel-grid",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "A flexible code implementation of the GEL Grid",
   "main": "_grid.scss",
   "scripts": {

--- a/test/test-expected.css
+++ b/test/test-expected.css
@@ -172,8 +172,16 @@
 }
 
 /**
-     * Disable the flexbox grid
+     * Disable the flexbox grid on core with display block
      */
+.gel-layout--no-flex,
+.gel-layout--no-flex > .gel-layout__item {
+  display: block;
+}
+
+/**
+        * Disable the flexbox grid on enhanced with display inline-block
+        */
 .gel-layout--no-flex,
 .gel-layout--no-flex > .gel-layout__item {
   display: inline-block;

--- a/test/test-expected.css
+++ b/test/test-expected.css
@@ -172,16 +172,13 @@
 }
 
 /**
-     * Disable the flexbox grid on core with display block
+     * Disable the flexbox grid
      */
 .gel-layout--no-flex,
 .gel-layout--no-flex > .gel-layout__item {
   display: block;
 }
 
-/**
-        * Disable the flexbox grid on enhanced with display inline-block
-        */
 .gel-layout--no-flex,
 .gel-layout--no-flex > .gel-layout__item {
   display: inline-block;

--- a/test/test-expected.css
+++ b/test/test-expected.css
@@ -177,10 +177,6 @@
 .gel-layout--no-flex,
 .gel-layout--no-flex > .gel-layout__item {
   display: block;
-}
-
-.gel-layout--no-flex,
-.gel-layout--no-flex > .gel-layout__item {
   display: inline-block;
 }
 


### PR DESCRIPTION
On core we need display block and on enhanced display inline-block (as we do not want each promo to be 100% width on enhanced but on core we do)