### PR TITLE
Apply `flex-grow: 1` to gel-layout

### DIFF
--- a/lib/_tools.scss
+++ b/lib/_tools.scss
@@ -75,6 +75,9 @@
         -webkit-flex-flow: row wrap;
         -ms-flex-flow: row wrap;
         flex-flow: row wrap;
+        -webkit-flex-grow: 1;
+        -ms-flex-grow: 1;
+        flex-grow: 1;
         margin-right: 0; // [2]
         margin-left: -$gel-spacing-unit;
         padding-right: 0; // [2]

--- a/test/test-expected.css
+++ b/test/test-expected.css
@@ -27,8 +27,8 @@
      */
 .gel-layout {
   list-style: none;
-  direction: flip(ltr, rtl);
-  text-align: flip(left, right);
+  direction: ltr;
+  text-align: left;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
@@ -64,7 +64,7 @@
   width: 100%;
   display: inline-block;
   padding-left: 8px;
-  text-align: flip(left, right);
+  text-align: left;
   vertical-align: top;
   -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;
@@ -150,7 +150,7 @@
 }
 
 .gel-layout--right > .gel-layout__item {
-  text-align: flip(left, right);
+  text-align: left;
 }
 
 /**
@@ -164,7 +164,7 @@
 }
 
 .gel-layout--center > .gel-layout__item {
-  text-align: flip(left, right);
+  text-align: left;
 }
 
 /**
@@ -1425,8 +1425,8 @@
 
 .my-component {
   list-style: none;
-  direction: flip(ltr, rtl);
-  text-align: flip(left, right);
+  direction: ltr;
+  text-align: left;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
@@ -1459,7 +1459,7 @@
   width: 100%;
   display: inline-block;
   padding-left: 8px;
-  text-align: flip(left, right);
+  text-align: left;
   vertical-align: top;
   -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;

--- a/test/test-expected.css
+++ b/test/test-expected.css
@@ -35,6 +35,9 @@
   -webkit-flex-flow: row wrap;
   -ms-flex-flow: row wrap;
   flex-flow: row wrap;
+  -webkit-flex-grow: 1;
+  -ms-flex-grow: 1;
+  flex-grow: 1;
   margin-right: 0;
   margin-left: -8px;
   padding-right: 0;
@@ -1430,6 +1433,9 @@
   -webkit-flex-flow: row wrap;
   -ms-flex-flow: row wrap;
   flex-flow: row wrap;
+  -webkit-flex-grow: 1;
+  -ms-flex-grow: 1;
+  flex-grow: 1;
   margin-right: 0;
   margin-left: -8px;
   padding-right: 0;


### PR DESCRIPTION
This forces the layout element to grow to fit its parent, even if its contents are not large enough to fill that space.

I've tested this on the news-5-slice and news-top-stories components in FF 51, Chrome 52, and Safari 10. These all have relatively complex nested grids.

## Without `flex-grow: 1` - contents dictate the layout size

![flex-grow](https://cloud.githubusercontent.com/assets/794263/18814731/448820c0-8314-11e6-8e88-95644867ab18.gif)

_(Ignore the weird grey-white colour change; that's GIF choosing a bad colour palette.)_

## With `flex-grow: 1` - layout grows to fit the parent regardless of contents

![screen shot 2016-09-25 at 11 43 35](https://cloud.githubusercontent.com/assets/794263/18814790/53f47b2a-8315-11e6-8b52-77ac59690ad9.png)

