### PR TITLE
Don't use  for equal layout items

### DIFF
--- a/lib/_tools.scss
+++ b/lib/_tools.scss
@@ -286,7 +286,6 @@
         .#{$gel-grid-namespace}layout--equal {
             > .#{$gel-grid-namespace}layout__item {
                 display: -webkit-flex;
-                display: -ms-flexbox;
                 display: flex;
             }
         }

--- a/test/test-expected.css
+++ b/test/test-expected.css
@@ -188,7 +188,6 @@
          */
 .gel-layout--equal > .gel-layout__item {
   display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 


### PR DESCRIPTION
IE10 doesn't fully support the flexbox spec. One of the issues we have encountered is that .gel-layout--equal behaves weirdly. I pinned it down to the `display: -ms-flexbox`. We can safely remove it because IE11 can use the non-prefixed property instead.

## Current IE10 behaviour

The keyline ::after elements are not correctly inserted into the flex flow.

![screen shot 2016-09-26 at 15 48 48](https://cloud.githubusercontent.com/assets/794263/18839063/8f612874-8401-11e6-92b4-d38a8a5ac3e4.png)

## Without `display: -ms-flexbox`

IE10 falls back to some sensible non-flex behaviour in the gel-layout__items.

![screen shot 2016-09-26 at 15 49 23](https://cloud.githubusercontent.com/assets/794263/18839088/a72c6202-8401-11e6-89c8-295ad97d6414.png)
