### PR TITLE
Add border-box fix to gel-wrap

### DIFF
--- a/lib/_tools.scss
+++ b/lib/_tools.scss
@@ -29,6 +29,12 @@
             padding-right: double($gel-spacing-unit);
         }
 
+        @if $gel-grid-enable--box-sizing {
+            -webkit-box-sizing: border-box;
+               -moz-box-sizing: border-box;
+                    box-sizing: border-box;
+        }
+
         @if $gel-grid-enable--1280-breakpoint {
             @if $gel-grid-1280-toggle-class != null {
                 .#{$gel-grid-1280-toggle-class} & {

--- a/test/test-expected.css
+++ b/test/test-expected.css
@@ -7,6 +7,9 @@
   margin: 0 auto;
   padding-right: 8px;
   padding-left: 8px;
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
 }
 
 @media (min-width: 25em) {
@@ -1407,6 +1410,9 @@
   margin: 0 auto;
   padding-right: 8px;
   padding-left: 8px;
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
 }
 
 @media (min-width: 25em) {


### PR DESCRIPTION
Looking at our site using `gel-wrap`, it's not lining up correctly and I think it's because we don't have the box-sizing fix by default and the `border-sizing: border-box` fix isn't applied to gel-wrap?

Testing with this fix and `$gel-grid-enable--box-sizing: true;` in our scss seems to fix it.
