### PR TITLE
Correction for the float fix in #32

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "gel-grid",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "homepage": "http://www.bbc.co.uk/gel",
   "authors": [
     "Shaun Bent <shaun.bent@bbc.co.uk>"

--- a/lib/_tools.scss
+++ b/lib/_tools.scss
@@ -276,8 +276,8 @@
      * 1. Prevents floated layout items from shrinking the layout
      */
     .#{$gel-grid-namespace}layout--no-flex {
-	width: 100%; // [1]
-	    
+	min-width: 100%; // [1]
+
         &,
         > .#{$gel-grid-namespace}layout__item {
             display: block;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gel-grid",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "A flexible code implementation of the GEL Grid",
   "main": "_grid.scss",
   "scripts": {

--- a/test/test-expected.css
+++ b/test/test-expected.css
@@ -183,7 +183,7 @@
      * 1. Prevents floated layout items from shrinking the layout
      */
 .gel-layout--no-flex {
-  width: 100%;
+  min-width: 100%;
 }
 
 .gel-layout--no-flex,


### PR DESCRIPTION
Turns out the fix in #32 was a bit over-enthusiastic and actually shrinks some layouts which (for some reason) need to be >100%.

This is a little tweak to get around that.