### PR TITLE
Avoid duplicate widths

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "gel-grid",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "homepage": "http://www.bbc.co.uk/gel",
   "authors": [
     "Shaun Bent <shaun.bent@bbc.co.uk>"

--- a/lib/_tools.scss
+++ b/lib/_tools.scss
@@ -415,6 +415,7 @@
 // @author Shaun Bent
 //
 @mixin _gel-widths($columns, $breakpoint: null) {
+    $output-widths: ();
     $breakpoint-suffix: '';
 
     @if $breakpoint != null {
@@ -429,9 +430,15 @@
 			}
 		} @else {
 			@for $i from 1 to $column {
-				.#{$gel-grid-namespace}#{$i}\/#{$column}#{$breakpoint-suffix} {
-					width: gel-columns($i / $column) !important;
-				}
+                $width: $i / $column;
+
+                @if map-has-key($output-widths, $width) == false {
+                    $output-widths: map-merge($output-widths, ($width: true));
+
+                    .#{$gel-grid-namespace}#{$i}\/#{$column}#{$breakpoint-suffix} {
+                        width: gel-columns($width) !important;
+                    }
+                }
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gel-grid",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "description": "A flexible code implementation of the GEL Grid",
   "main": "_grid.scss",
   "scripts": {

--- a/test/test-expected.css
+++ b/test/test-expected.css
@@ -257,10 +257,6 @@
   width: 25% !important;
 }
 
-.gel-2\/4 {
-  width: 50% !important;
-}
-
 .gel-3\/4 {
   width: 75% !important;
 }
@@ -285,24 +281,12 @@
   width: 12.5% !important;
 }
 
-.gel-2\/8 {
-  width: 25% !important;
-}
-
 .gel-3\/8 {
   width: 37.5% !important;
 }
 
-.gel-4\/8 {
-  width: 50% !important;
-}
-
 .gel-5\/8 {
   width: 62.5% !important;
-}
-
-.gel-6\/8 {
-  width: 75% !important;
 }
 
 .gel-7\/8 {
@@ -313,32 +297,12 @@
   width: 10% !important;
 }
 
-.gel-2\/10 {
-  width: 20% !important;
-}
-
 .gel-3\/10 {
   width: 30% !important;
 }
 
-.gel-4\/10 {
-  width: 40% !important;
-}
-
-.gel-5\/10 {
-  width: 50% !important;
-}
-
-.gel-6\/10 {
-  width: 60% !important;
-}
-
 .gel-7\/10 {
   width: 70% !important;
-}
-
-.gel-8\/10 {
-  width: 80% !important;
 }
 
 .gel-9\/10 {
@@ -353,32 +317,12 @@
   width: 16.66667% !important;
 }
 
-.gel-3\/12 {
-  width: 25% !important;
-}
-
-.gel-4\/12 {
-  width: 33.33333% !important;
-}
-
 .gel-5\/12 {
   width: 41.66667% !important;
 }
 
-.gel-6\/12 {
-  width: 50% !important;
-}
-
 .gel-7\/12 {
   width: 58.33333% !important;
-}
-
-.gel-8\/12 {
-  width: 66.66667% !important;
-}
-
-.gel-9\/12 {
-  width: 75% !important;
 }
 
 .gel-10\/12 {
@@ -393,88 +337,28 @@
   width: 4.16667% !important;
 }
 
-.gel-2\/24 {
-  width: 8.33333% !important;
-}
-
-.gel-3\/24 {
-  width: 12.5% !important;
-}
-
-.gel-4\/24 {
-  width: 16.66667% !important;
-}
-
 .gel-5\/24 {
   width: 20.83333% !important;
-}
-
-.gel-6\/24 {
-  width: 25% !important;
 }
 
 .gel-7\/24 {
   width: 29.16667% !important;
 }
 
-.gel-8\/24 {
-  width: 33.33333% !important;
-}
-
-.gel-9\/24 {
-  width: 37.5% !important;
-}
-
-.gel-10\/24 {
-  width: 41.66667% !important;
-}
-
 .gel-11\/24 {
   width: 45.83333% !important;
-}
-
-.gel-12\/24 {
-  width: 50% !important;
 }
 
 .gel-13\/24 {
   width: 54.16667% !important;
 }
 
-.gel-14\/24 {
-  width: 58.33333% !important;
-}
-
-.gel-15\/24 {
-  width: 62.5% !important;
-}
-
-.gel-16\/24 {
-  width: 66.66667% !important;
-}
-
 .gel-17\/24 {
   width: 70.83333% !important;
 }
 
-.gel-18\/24 {
-  width: 75% !important;
-}
-
 .gel-19\/24 {
   width: 79.16667% !important;
-}
-
-.gel-20\/24 {
-  width: 83.33333% !important;
-}
-
-.gel-21\/24 {
-  width: 87.5% !important;
-}
-
-.gel-22\/24 {
-  width: 91.66667% !important;
 }
 
 .gel-23\/24 {
@@ -497,9 +381,6 @@
   .gel-1\/4\@s {
     width: 25% !important;
   }
-  .gel-2\/4\@s {
-    width: 50% !important;
-  }
   .gel-3\/4\@s {
     width: 75% !important;
   }
@@ -518,20 +399,11 @@
   .gel-1\/8\@s {
     width: 12.5% !important;
   }
-  .gel-2\/8\@s {
-    width: 25% !important;
-  }
   .gel-3\/8\@s {
     width: 37.5% !important;
   }
-  .gel-4\/8\@s {
-    width: 50% !important;
-  }
   .gel-5\/8\@s {
     width: 62.5% !important;
-  }
-  .gel-6\/8\@s {
-    width: 75% !important;
   }
   .gel-7\/8\@s {
     width: 87.5% !important;
@@ -539,26 +411,11 @@
   .gel-1\/10\@s {
     width: 10% !important;
   }
-  .gel-2\/10\@s {
-    width: 20% !important;
-  }
   .gel-3\/10\@s {
     width: 30% !important;
   }
-  .gel-4\/10\@s {
-    width: 40% !important;
-  }
-  .gel-5\/10\@s {
-    width: 50% !important;
-  }
-  .gel-6\/10\@s {
-    width: 60% !important;
-  }
   .gel-7\/10\@s {
     width: 70% !important;
-  }
-  .gel-8\/10\@s {
-    width: 80% !important;
   }
   .gel-9\/10\@s {
     width: 90% !important;
@@ -569,26 +426,11 @@
   .gel-2\/12\@s {
     width: 16.66667% !important;
   }
-  .gel-3\/12\@s {
-    width: 25% !important;
-  }
-  .gel-4\/12\@s {
-    width: 33.33333% !important;
-  }
   .gel-5\/12\@s {
     width: 41.66667% !important;
   }
-  .gel-6\/12\@s {
-    width: 50% !important;
-  }
   .gel-7\/12\@s {
     width: 58.33333% !important;
-  }
-  .gel-8\/12\@s {
-    width: 66.66667% !important;
-  }
-  .gel-9\/12\@s {
-    width: 75% !important;
   }
   .gel-10\/12\@s {
     width: 83.33333% !important;
@@ -599,68 +441,23 @@
   .gel-1\/24\@s {
     width: 4.16667% !important;
   }
-  .gel-2\/24\@s {
-    width: 8.33333% !important;
-  }
-  .gel-3\/24\@s {
-    width: 12.5% !important;
-  }
-  .gel-4\/24\@s {
-    width: 16.66667% !important;
-  }
   .gel-5\/24\@s {
     width: 20.83333% !important;
-  }
-  .gel-6\/24\@s {
-    width: 25% !important;
   }
   .gel-7\/24\@s {
     width: 29.16667% !important;
   }
-  .gel-8\/24\@s {
-    width: 33.33333% !important;
-  }
-  .gel-9\/24\@s {
-    width: 37.5% !important;
-  }
-  .gel-10\/24\@s {
-    width: 41.66667% !important;
-  }
   .gel-11\/24\@s {
     width: 45.83333% !important;
-  }
-  .gel-12\/24\@s {
-    width: 50% !important;
   }
   .gel-13\/24\@s {
     width: 54.16667% !important;
   }
-  .gel-14\/24\@s {
-    width: 58.33333% !important;
-  }
-  .gel-15\/24\@s {
-    width: 62.5% !important;
-  }
-  .gel-16\/24\@s {
-    width: 66.66667% !important;
-  }
   .gel-17\/24\@s {
     width: 70.83333% !important;
   }
-  .gel-18\/24\@s {
-    width: 75% !important;
-  }
   .gel-19\/24\@s {
     width: 79.16667% !important;
-  }
-  .gel-20\/24\@s {
-    width: 83.33333% !important;
-  }
-  .gel-21\/24\@s {
-    width: 87.5% !important;
-  }
-  .gel-22\/24\@s {
-    width: 91.66667% !important;
   }
   .gel-23\/24\@s {
     width: 95.83333% !important;
@@ -683,9 +480,6 @@
   .gel-1\/4\@m {
     width: 25% !important;
   }
-  .gel-2\/4\@m {
-    width: 50% !important;
-  }
   .gel-3\/4\@m {
     width: 75% !important;
   }
@@ -704,20 +498,11 @@
   .gel-1\/8\@m {
     width: 12.5% !important;
   }
-  .gel-2\/8\@m {
-    width: 25% !important;
-  }
   .gel-3\/8\@m {
     width: 37.5% !important;
   }
-  .gel-4\/8\@m {
-    width: 50% !important;
-  }
   .gel-5\/8\@m {
     width: 62.5% !important;
-  }
-  .gel-6\/8\@m {
-    width: 75% !important;
   }
   .gel-7\/8\@m {
     width: 87.5% !important;
@@ -725,26 +510,11 @@
   .gel-1\/10\@m {
     width: 10% !important;
   }
-  .gel-2\/10\@m {
-    width: 20% !important;
-  }
   .gel-3\/10\@m {
     width: 30% !important;
   }
-  .gel-4\/10\@m {
-    width: 40% !important;
-  }
-  .gel-5\/10\@m {
-    width: 50% !important;
-  }
-  .gel-6\/10\@m {
-    width: 60% !important;
-  }
   .gel-7\/10\@m {
     width: 70% !important;
-  }
-  .gel-8\/10\@m {
-    width: 80% !important;
   }
   .gel-9\/10\@m {
     width: 90% !important;
@@ -755,26 +525,11 @@
   .gel-2\/12\@m {
     width: 16.66667% !important;
   }
-  .gel-3\/12\@m {
-    width: 25% !important;
-  }
-  .gel-4\/12\@m {
-    width: 33.33333% !important;
-  }
   .gel-5\/12\@m {
     width: 41.66667% !important;
   }
-  .gel-6\/12\@m {
-    width: 50% !important;
-  }
   .gel-7\/12\@m {
     width: 58.33333% !important;
-  }
-  .gel-8\/12\@m {
-    width: 66.66667% !important;
-  }
-  .gel-9\/12\@m {
-    width: 75% !important;
   }
   .gel-10\/12\@m {
     width: 83.33333% !important;
@@ -785,68 +540,23 @@
   .gel-1\/24\@m {
     width: 4.16667% !important;
   }
-  .gel-2\/24\@m {
-    width: 8.33333% !important;
-  }
-  .gel-3\/24\@m {
-    width: 12.5% !important;
-  }
-  .gel-4\/24\@m {
-    width: 16.66667% !important;
-  }
   .gel-5\/24\@m {
     width: 20.83333% !important;
-  }
-  .gel-6\/24\@m {
-    width: 25% !important;
   }
   .gel-7\/24\@m {
     width: 29.16667% !important;
   }
-  .gel-8\/24\@m {
-    width: 33.33333% !important;
-  }
-  .gel-9\/24\@m {
-    width: 37.5% !important;
-  }
-  .gel-10\/24\@m {
-    width: 41.66667% !important;
-  }
   .gel-11\/24\@m {
     width: 45.83333% !important;
-  }
-  .gel-12\/24\@m {
-    width: 50% !important;
   }
   .gel-13\/24\@m {
     width: 54.16667% !important;
   }
-  .gel-14\/24\@m {
-    width: 58.33333% !important;
-  }
-  .gel-15\/24\@m {
-    width: 62.5% !important;
-  }
-  .gel-16\/24\@m {
-    width: 66.66667% !important;
-  }
   .gel-17\/24\@m {
     width: 70.83333% !important;
   }
-  .gel-18\/24\@m {
-    width: 75% !important;
-  }
   .gel-19\/24\@m {
     width: 79.16667% !important;
-  }
-  .gel-20\/24\@m {
-    width: 83.33333% !important;
-  }
-  .gel-21\/24\@m {
-    width: 87.5% !important;
-  }
-  .gel-22\/24\@m {
-    width: 91.66667% !important;
   }
   .gel-23\/24\@m {
     width: 95.83333% !important;
@@ -869,9 +579,6 @@
   .gel-1\/4\@l {
     width: 25% !important;
   }
-  .gel-2\/4\@l {
-    width: 50% !important;
-  }
   .gel-3\/4\@l {
     width: 75% !important;
   }
@@ -890,20 +597,11 @@
   .gel-1\/8\@l {
     width: 12.5% !important;
   }
-  .gel-2\/8\@l {
-    width: 25% !important;
-  }
   .gel-3\/8\@l {
     width: 37.5% !important;
   }
-  .gel-4\/8\@l {
-    width: 50% !important;
-  }
   .gel-5\/8\@l {
     width: 62.5% !important;
-  }
-  .gel-6\/8\@l {
-    width: 75% !important;
   }
   .gel-7\/8\@l {
     width: 87.5% !important;
@@ -911,26 +609,11 @@
   .gel-1\/10\@l {
     width: 10% !important;
   }
-  .gel-2\/10\@l {
-    width: 20% !important;
-  }
   .gel-3\/10\@l {
     width: 30% !important;
   }
-  .gel-4\/10\@l {
-    width: 40% !important;
-  }
-  .gel-5\/10\@l {
-    width: 50% !important;
-  }
-  .gel-6\/10\@l {
-    width: 60% !important;
-  }
   .gel-7\/10\@l {
     width: 70% !important;
-  }
-  .gel-8\/10\@l {
-    width: 80% !important;
   }
   .gel-9\/10\@l {
     width: 90% !important;
@@ -941,26 +624,11 @@
   .gel-2\/12\@l {
     width: 16.66667% !important;
   }
-  .gel-3\/12\@l {
-    width: 25% !important;
-  }
-  .gel-4\/12\@l {
-    width: 33.33333% !important;
-  }
   .gel-5\/12\@l {
     width: 41.66667% !important;
   }
-  .gel-6\/12\@l {
-    width: 50% !important;
-  }
   .gel-7\/12\@l {
     width: 58.33333% !important;
-  }
-  .gel-8\/12\@l {
-    width: 66.66667% !important;
-  }
-  .gel-9\/12\@l {
-    width: 75% !important;
   }
   .gel-10\/12\@l {
     width: 83.33333% !important;
@@ -971,68 +639,23 @@
   .gel-1\/24\@l {
     width: 4.16667% !important;
   }
-  .gel-2\/24\@l {
-    width: 8.33333% !important;
-  }
-  .gel-3\/24\@l {
-    width: 12.5% !important;
-  }
-  .gel-4\/24\@l {
-    width: 16.66667% !important;
-  }
   .gel-5\/24\@l {
     width: 20.83333% !important;
-  }
-  .gel-6\/24\@l {
-    width: 25% !important;
   }
   .gel-7\/24\@l {
     width: 29.16667% !important;
   }
-  .gel-8\/24\@l {
-    width: 33.33333% !important;
-  }
-  .gel-9\/24\@l {
-    width: 37.5% !important;
-  }
-  .gel-10\/24\@l {
-    width: 41.66667% !important;
-  }
   .gel-11\/24\@l {
     width: 45.83333% !important;
-  }
-  .gel-12\/24\@l {
-    width: 50% !important;
   }
   .gel-13\/24\@l {
     width: 54.16667% !important;
   }
-  .gel-14\/24\@l {
-    width: 58.33333% !important;
-  }
-  .gel-15\/24\@l {
-    width: 62.5% !important;
-  }
-  .gel-16\/24\@l {
-    width: 66.66667% !important;
-  }
   .gel-17\/24\@l {
     width: 70.83333% !important;
   }
-  .gel-18\/24\@l {
-    width: 75% !important;
-  }
   .gel-19\/24\@l {
     width: 79.16667% !important;
-  }
-  .gel-20\/24\@l {
-    width: 83.33333% !important;
-  }
-  .gel-21\/24\@l {
-    width: 87.5% !important;
-  }
-  .gel-22\/24\@l {
-    width: 91.66667% !important;
   }
   .gel-23\/24\@l {
     width: 95.83333% !important;
@@ -1055,9 +678,6 @@
   .gel-1\/4\@xl {
     width: 25% !important;
   }
-  .gel-2\/4\@xl {
-    width: 50% !important;
-  }
   .gel-3\/4\@xl {
     width: 75% !important;
   }
@@ -1076,20 +696,11 @@
   .gel-1\/8\@xl {
     width: 12.5% !important;
   }
-  .gel-2\/8\@xl {
-    width: 25% !important;
-  }
   .gel-3\/8\@xl {
     width: 37.5% !important;
   }
-  .gel-4\/8\@xl {
-    width: 50% !important;
-  }
   .gel-5\/8\@xl {
     width: 62.5% !important;
-  }
-  .gel-6\/8\@xl {
-    width: 75% !important;
   }
   .gel-7\/8\@xl {
     width: 87.5% !important;
@@ -1097,26 +708,11 @@
   .gel-1\/10\@xl {
     width: 10% !important;
   }
-  .gel-2\/10\@xl {
-    width: 20% !important;
-  }
   .gel-3\/10\@xl {
     width: 30% !important;
   }
-  .gel-4\/10\@xl {
-    width: 40% !important;
-  }
-  .gel-5\/10\@xl {
-    width: 50% !important;
-  }
-  .gel-6\/10\@xl {
-    width: 60% !important;
-  }
   .gel-7\/10\@xl {
     width: 70% !important;
-  }
-  .gel-8\/10\@xl {
-    width: 80% !important;
   }
   .gel-9\/10\@xl {
     width: 90% !important;
@@ -1127,26 +723,11 @@
   .gel-2\/12\@xl {
     width: 16.66667% !important;
   }
-  .gel-3\/12\@xl {
-    width: 25% !important;
-  }
-  .gel-4\/12\@xl {
-    width: 33.33333% !important;
-  }
   .gel-5\/12\@xl {
     width: 41.66667% !important;
   }
-  .gel-6\/12\@xl {
-    width: 50% !important;
-  }
   .gel-7\/12\@xl {
     width: 58.33333% !important;
-  }
-  .gel-8\/12\@xl {
-    width: 66.66667% !important;
-  }
-  .gel-9\/12\@xl {
-    width: 75% !important;
   }
   .gel-10\/12\@xl {
     width: 83.33333% !important;
@@ -1157,68 +738,23 @@
   .gel-1\/24\@xl {
     width: 4.16667% !important;
   }
-  .gel-2\/24\@xl {
-    width: 8.33333% !important;
-  }
-  .gel-3\/24\@xl {
-    width: 12.5% !important;
-  }
-  .gel-4\/24\@xl {
-    width: 16.66667% !important;
-  }
   .gel-5\/24\@xl {
     width: 20.83333% !important;
-  }
-  .gel-6\/24\@xl {
-    width: 25% !important;
   }
   .gel-7\/24\@xl {
     width: 29.16667% !important;
   }
-  .gel-8\/24\@xl {
-    width: 33.33333% !important;
-  }
-  .gel-9\/24\@xl {
-    width: 37.5% !important;
-  }
-  .gel-10\/24\@xl {
-    width: 41.66667% !important;
-  }
   .gel-11\/24\@xl {
     width: 45.83333% !important;
-  }
-  .gel-12\/24\@xl {
-    width: 50% !important;
   }
   .gel-13\/24\@xl {
     width: 54.16667% !important;
   }
-  .gel-14\/24\@xl {
-    width: 58.33333% !important;
-  }
-  .gel-15\/24\@xl {
-    width: 62.5% !important;
-  }
-  .gel-16\/24\@xl {
-    width: 66.66667% !important;
-  }
   .gel-17\/24\@xl {
     width: 70.83333% !important;
   }
-  .gel-18\/24\@xl {
-    width: 75% !important;
-  }
   .gel-19\/24\@xl {
     width: 79.16667% !important;
-  }
-  .gel-20\/24\@xl {
-    width: 83.33333% !important;
-  }
-  .gel-21\/24\@xl {
-    width: 87.5% !important;
-  }
-  .gel-22\/24\@xl {
-    width: 91.66667% !important;
   }
   .gel-23\/24\@xl {
     width: 95.83333% !important;
@@ -1241,9 +777,6 @@
   .gel-1\/4\@xxl {
     width: 25% !important;
   }
-  .gel-2\/4\@xxl {
-    width: 50% !important;
-  }
   .gel-3\/4\@xxl {
     width: 75% !important;
   }
@@ -1262,20 +795,11 @@
   .gel-1\/8\@xxl {
     width: 12.5% !important;
   }
-  .gel-2\/8\@xxl {
-    width: 25% !important;
-  }
   .gel-3\/8\@xxl {
     width: 37.5% !important;
   }
-  .gel-4\/8\@xxl {
-    width: 50% !important;
-  }
   .gel-5\/8\@xxl {
     width: 62.5% !important;
-  }
-  .gel-6\/8\@xxl {
-    width: 75% !important;
   }
   .gel-7\/8\@xxl {
     width: 87.5% !important;
@@ -1283,26 +807,11 @@
   .gel-1\/10\@xxl {
     width: 10% !important;
   }
-  .gel-2\/10\@xxl {
-    width: 20% !important;
-  }
   .gel-3\/10\@xxl {
     width: 30% !important;
   }
-  .gel-4\/10\@xxl {
-    width: 40% !important;
-  }
-  .gel-5\/10\@xxl {
-    width: 50% !important;
-  }
-  .gel-6\/10\@xxl {
-    width: 60% !important;
-  }
   .gel-7\/10\@xxl {
     width: 70% !important;
-  }
-  .gel-8\/10\@xxl {
-    width: 80% !important;
   }
   .gel-9\/10\@xxl {
     width: 90% !important;
@@ -1313,26 +822,11 @@
   .gel-2\/12\@xxl {
     width: 16.66667% !important;
   }
-  .gel-3\/12\@xxl {
-    width: 25% !important;
-  }
-  .gel-4\/12\@xxl {
-    width: 33.33333% !important;
-  }
   .gel-5\/12\@xxl {
     width: 41.66667% !important;
   }
-  .gel-6\/12\@xxl {
-    width: 50% !important;
-  }
   .gel-7\/12\@xxl {
     width: 58.33333% !important;
-  }
-  .gel-8\/12\@xxl {
-    width: 66.66667% !important;
-  }
-  .gel-9\/12\@xxl {
-    width: 75% !important;
   }
   .gel-10\/12\@xxl {
     width: 83.33333% !important;
@@ -1343,68 +837,23 @@
   .gel-1\/24\@xxl {
     width: 4.16667% !important;
   }
-  .gel-2\/24\@xxl {
-    width: 8.33333% !important;
-  }
-  .gel-3\/24\@xxl {
-    width: 12.5% !important;
-  }
-  .gel-4\/24\@xxl {
-    width: 16.66667% !important;
-  }
   .gel-5\/24\@xxl {
     width: 20.83333% !important;
-  }
-  .gel-6\/24\@xxl {
-    width: 25% !important;
   }
   .gel-7\/24\@xxl {
     width: 29.16667% !important;
   }
-  .gel-8\/24\@xxl {
-    width: 33.33333% !important;
-  }
-  .gel-9\/24\@xxl {
-    width: 37.5% !important;
-  }
-  .gel-10\/24\@xxl {
-    width: 41.66667% !important;
-  }
   .gel-11\/24\@xxl {
     width: 45.83333% !important;
-  }
-  .gel-12\/24\@xxl {
-    width: 50% !important;
   }
   .gel-13\/24\@xxl {
     width: 54.16667% !important;
   }
-  .gel-14\/24\@xxl {
-    width: 58.33333% !important;
-  }
-  .gel-15\/24\@xxl {
-    width: 62.5% !important;
-  }
-  .gel-16\/24\@xxl {
-    width: 66.66667% !important;
-  }
   .gel-17\/24\@xxl {
     width: 70.83333% !important;
   }
-  .gel-18\/24\@xxl {
-    width: 75% !important;
-  }
   .gel-19\/24\@xxl {
     width: 79.16667% !important;
-  }
-  .gel-20\/24\@xxl {
-    width: 83.33333% !important;
-  }
-  .gel-21\/24\@xxl {
-    width: 87.5% !important;
-  }
-  .gel-22\/24\@xxl {
-    width: 91.66667% !important;
   }
   .gel-23\/24\@xxl {
     width: 95.83333% !important;


### PR DESCRIPTION
## What?

Keep track of all output widths to make sure each width class is only output once. This removes a bunch of classes, so it's a breaking change. See the diff below for a full list of removed classes.

## Why?

Savin' bytes! 💸 

## Size difference

| | gel-grid.css | gel-grid.css / gzip | gel-grid.min.css | gel-grid.min.css / gzip |
|-|----------------|------------------------|----------------------|-----------------------------|
| **Before** | 23239 bytes | 2831 bytes | 16661 bytes | 2211 bytes |
| **After** | 14426 bytes | 2127 bytes | 10139 bytes | 1475 bytes |
| **Difference** | **38% smaller** | **25% smaller** | **39% smaller** | **33% smaller** |

## Diff

[Link because the diff is biiiig](https://gist.github.com/wildlyinaccurate/e76460cf981d7dd97d917c3c72cd89ff)