### PR TITLE
feat: Using / for division is deprecated

### DIFF
--- a/lib/_tools.scss
+++ b/lib/_tools.scss
@@ -1,3 +1,5 @@
+@use 'sass:math';
+
 ///*------------------------------------*\
 //    # GEL GRID - TOOLS
 //\*------------------------------------*/
@@ -451,7 +453,7 @@
 		} @else {
 			@for $i from 1 to $column {
                 // dart-sass does not support precision, so do it manually
-                $width: round(($i / $column) * 10000000) / 10000000;
+                $width: math.div(round(math.div($i, $column) * 10000000), 10000000);
 
                 @if map-has-key($output-widths, $width) == false {
                     $output-widths: map-merge($output-widths, ($width: true));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gel-grid",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -30,19 +30,19 @@
       }
     },
     "chokidar": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
-      "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
+      "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
       "dev": true,
       "requires": {
-        "anymatch": "~3.1.1",
+        "anymatch": "~3.1.2",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.1",
-        "glob-parent": "~5.1.0",
+        "fsevents": "~2.3.2",
+        "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
-        "readdirp": "~3.5.0"
+        "readdirp": "~3.6.0"
       }
     },
     "fill-range": {
@@ -62,18 +62,11 @@
       "optional": true
     },
     "gel-sass-tools": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/gel-sass-tools/-/gel-sass-tools-2.0.0.tgz",
-      "integrity": "sha512-FIwA+AHaijQEkVxsA+d7FurS7RSVM05gjV6IitwbQKiu6BHF8yfE7CUHRS6t8gV55fINv3mMeIzmOIdifjQg3w==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/gel-sass-tools/-/gel-sass-tools-2.1.0.tgz",
+      "integrity": "sha512-AUfybZkX9rzIoitWdJ2+UvxbBi9L69+p7uYmTCBLozb+E3w8Pggvh+0NH3YWO8znv5N5RAnSTyeJSjGp0M/RPg==",
       "requires": {
-        "sass-mq": "3.2.3"
-      },
-      "dependencies": {
-        "sass-mq": {
-          "version": "3.2.3",
-          "resolved": "https://registry.npmjs.org/sass-mq/-/sass-mq-3.2.3.tgz",
-          "integrity": "sha1-n4dL+h69IhD8L7Tlm4dA35ip4ug="
-        }
+        "sass-mq": "5.0.1"
       }
     },
     "glob-parent": {
@@ -101,9 +94,9 @@
       "dev": true
     },
     "is-glob": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
       "requires": {
         "is-extglob": "^2.1.1"
@@ -122,24 +115,24 @@
       "dev": true
     },
     "picomatch": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.3.tgz",
-      "integrity": "sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
       "dev": true
     },
     "readdirp": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
-      "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "dev": true,
       "requires": {
         "picomatch": "^2.2.1"
       }
     },
     "sass": {
-      "version": "1.32.12",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.32.12.tgz",
-      "integrity": "sha512-zmXn03k3hN0KaiVTjohgkg98C3UowhL1/VSGdj4/VAAiMKGQOE80PFPxFP2Kyq0OUskPKcY5lImkhBKEHlypJA==",
+      "version": "1.42.1",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.42.1.tgz",
+      "integrity": "sha512-/zvGoN8B7dspKc5mC6HlaygyCBRvnyzzgD5khiaCfglWztY99cYoiTUksVx11NlnemrcfH5CEaCpsUKoW0cQqg==",
       "dev": true,
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0"
@@ -148,8 +141,7 @@
     "sass-mq": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/sass-mq/-/sass-mq-5.0.1.tgz",
-      "integrity": "sha512-ugSVZO5fzasSFrGfKCtY02spnkOOfo9U9sXuzCuSXoCl1CgcoqdJRdNmigZkhvRVph1GKM6o0pgI00Jjc445CA==",
-      "dev": true
+      "integrity": "sha512-ugSVZO5fzasSFrGfKCtY02spnkOOfo9U9sXuzCuSXoCl1CgcoqdJRdNmigZkhvRVph1GKM6o0pgI00Jjc445CA=="
     },
     "to-regex-range": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gel-grid",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "A flexible code implementation of the GEL Grid",
   "main": "_grid.scss",
   "scripts": {
@@ -34,10 +34,10 @@
   },
   "homepage": "https://github.com/bbc/gel-grid",
   "devDependencies": {
-    "sass": "1.32.12",
+    "sass": "1.42.1",
     "sass-mq": "5.0.1"
   },
   "dependencies": {
-    "gel-sass-tools": "2.0.0"
+    "gel-sass-tools": "2.1.0"
   }
 }


### PR DESCRIPTION
## Description
Switches to use `math.div` instead of ` / ` as Dart 2 will not support it
and is already displaying deprecation warnings.

## Issue
https://github.com/bbc/gel-grid/issues/48