### PR TITLE
feat: Remove $core, $enhanced and $fixed variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ v7.0.0 of GEL Grid implements the [@use](https://sass-lang.com/documentation/at-
 
 This has a number of consequences; how modules are loaded, and how to access variables. Namespaces now come into play, so please read the sass documentation links above to learn more.
 
+The properties output from this module could be controlled via three variables: $core, $enhanced and $fixed. These three variables allowed for control of the output, where core functionality could be separated out from enhanced functionality (for more advanced browsers) and for Internet Explorer (fixed).
+
+As browsers have moved on significantly since this approach was adopted it is considered a good time to remove this functionality.
+
 For usage of GEL Grid prior to v7.0.0 please reference the [v6.3.0 readme](https://github.com/bbc/gel-grid/tree/6.3.0).
 
 ## What is this?

--- a/README.md
+++ b/README.md
@@ -200,10 +200,8 @@ The GEL grid component exposes a collection of Sass Mixins which can be called w
     @include grid.gel-layout-item;
     @include grid.gel-columns(1/2);
 
-    @if $enhanced {
-        @include mq.mq($from: gel-bp-m) {
-            @include grid.gel-columns(1/4);
-        }
+    @include mq.mq($from: gel-bp-m) {
+        @include grid.gel-columns(1/4);
     }
 }
 ```

--- a/lib/_tools.scss
+++ b/lib/_tools.scss
@@ -8,40 +8,31 @@
 //    # GEL GRID - TOOLS
 //\*------------------------------------*/
 
-// define some output control variables
-$enhanced: true !default;
-
 // Grid container, used to wrap all grid elements and apply the correct maximum widths
-//
-// 1. IE8 doesn't apply border-box box-sizing logic correctly on (min|max)-(width|height) properties.
-//    As we serve IE8 a none responsive layout, lets just use the `width` property
 //
 // @author Shaun Bent
 //
 @mixin gel-wrap() {
+  @if settings.$gel-grid-enable--box-sizing {
+    box-sizing: border-box;
+  }
   margin: 0 auto;
   max-width: settings.$gel-grid-max-width-1008;
   #{sass-tools.$padding-right}: sass-tools.$gel-spacing-unit;
   #{sass-tools.$padding-left}: sass-tools.$gel-spacing-unit;
 
-  @if $enhanced {
-    @if settings.$gel-grid-enable--box-sizing {
-      box-sizing: border-box;
-    }
+  @include mq.mq($from: settings.$gel-grid-margin-change) {
+    #{sass-tools.$padding-left}: sass-tools.double(sass-tools.$gel-spacing-unit);
+    #{sass-tools.$padding-right}: sass-tools.double(sass-tools.$gel-spacing-unit);
+  }
 
-    @include mq.mq($from: settings.$gel-grid-margin-change) {
-      #{sass-tools.$padding-left}: sass-tools.double(sass-tools.$gel-spacing-unit);
-      #{sass-tools.$padding-right}: sass-tools.double(sass-tools.$gel-spacing-unit);
-    }
-
-    @if settings.$gel-grid-enable--1280-breakpoint {
-      @if settings.$gel-grid-1280-toggle-class != null {
-        .#{settings.$gel-grid-1280-toggle-class} & {
-          @include gel-wrap-1280-breakpoint;
-        }
-      } @else {
+  @if settings.$gel-grid-enable--1280-breakpoint {
+    @if settings.$gel-grid-1280-toggle-class != null {
+      .#{settings.$gel-grid-1280-toggle-class} & {
         @include gel-wrap-1280-breakpoint;
       }
+    } @else {
+      @include gel-wrap-1280-breakpoint;
     }
   }
 }
@@ -64,34 +55,31 @@ $enhanced: true !default;
 //
 @mixin gel-layout() {
   direction: sass-tools.flip(ltr, rtl);
+  display: flex;
+  flex-flow: row wrap;
+  flex-grow: 1;
   list-style: none; // [1]
+  #{sass-tools.$margin-right}: 0; // [2]
+  #{sass-tools.$margin-left}: -(sass-tools.$gel-spacing-unit);
+  #{sass-tools.$padding-right}: 0; // [2]
+  #{sass-tools.$padding-left}: 0; // [2]
   text-align: sass-tools.flip(left, right);
 
-  @if $enhanced {
-    display: flex;
-    flex-flow: row wrap;
-    flex-grow: 1;
-    #{sass-tools.$margin-right}: 0; // [2]
-    #{sass-tools.$margin-left}: -(sass-tools.$gel-spacing-unit);
-    #{sass-tools.$padding-right}: 0; // [2]
-    #{sass-tools.$padding-left}: 0; // [2]
+  @if settings.$gel-grid-enable--whitespace-fix {
+    letter-spacing: -0.31em;
+    text-rendering: optimizespeed;
+  }
 
-    @if settings.$gel-grid-enable--whitespace-fix {
-      letter-spacing: -0.31em;
-      text-rendering: optimizespeed;
-    }
-
-    @if settings.$gel-grid-enable--whitespace-fix {
-      @at-root {
-        #{&} {
-          word-spacing: -0.43em;
-        }
+  @if settings.$gel-grid-enable--whitespace-fix {
+    @at-root {
+      #{&} {
+        word-spacing: -0.43em;
       }
     }
+  }
 
-    @include mq.mq($from: settings.$gel-grid-gutter-change) {
-      #{sass-tools.$margin-left}: sass-tools.double(-(sass-tools.$gel-spacing-unit));
-    }
+  @include mq.mq($from: settings.$gel-grid-gutter-change) {
+    #{sass-tools.$margin-left}: sass-tools.double(-(sass-tools.$gel-spacing-unit));
   }
 }
 
@@ -105,27 +93,23 @@ $enhanced: true !default;
 // @author  Shaun Bent
 //
 @mixin gel-layout-item() {
-  @if $enhanced {
-    width: 100%;
-    display: inline-block; // [1]
-    #{sass-tools.$padding-left}: sass-tools.$gel-spacing-unit; // [2]
+  @if settings.$gel-grid-enable--box-sizing {
+    box-sizing: border-box;
+  }
+  display: inline-block; // [1]
+  #{sass-tools.$padding-left}: sass-tools.$gel-spacing-unit; // [2]
+  text-align: sass-tools.flip(left, right); // [3]
+  vertical-align: top; // [4]
+  width: 100%;
 
-    text-align: sass-tools.flip(left, right); // [3]
-    vertical-align: top; // [4]
+  @if settings.$gel-grid-enable--whitespace-fix {
+    letter-spacing: normal;
+    text-rendering: auto;
+    word-spacing: normal;
+  }
 
-    @if settings.$gel-grid-enable--box-sizing {
-      box-sizing: border-box;
-    }
-
-    @if settings.$gel-grid-enable--whitespace-fix {
-      letter-spacing: normal;
-      text-rendering: auto;
-      word-spacing: normal;
-    }
-
-    @include mq.mq($from: settings.$gel-grid-gutter-change) {
-      #{sass-tools.$padding-left}: sass-tools.double(sass-tools.$gel-spacing-unit); // [2]
-    }
+  @include mq.mq($from: settings.$gel-grid-gutter-change) {
+    #{sass-tools.$padding-left}: sass-tools.double(sass-tools.$gel-spacing-unit); // [2]
   }
 }
 
@@ -135,29 +119,29 @@ $enhanced: true !default;
 //
 @mixin gel-output-grid() {
   /**
-     * Grid containing element
-     */
+    * Grid containing element
+    */
   .#{settings.$gel-grid-namespace}wrap {
     @include gel-wrap;
   }
 
   /**
-     * A grid row
-     */
+    * A grid row
+    */
   .#{settings.$gel-grid-namespace}layout {
     @include gel-layout;
   }
 
   /**
-     * A single grid item
-     */
+    * A single grid item
+    */
   .#{settings.$gel-grid-namespace}layout__item {
     @include gel-layout-item;
   }
 
   /**
-     * Layouts with no gutters.
-     */
+    * Layouts with no gutters.
+    */
   .#{settings.$gel-grid-namespace}layout--flush {
     #{sass-tools.$margin-left}: 0;
   }
@@ -169,9 +153,9 @@ $enhanced: true !default;
   }
 
   /**
-     * Reversed rendered order of layout items, e.g. items 1, 2, 3, 4 in your
-     * markup will display in order 4, 3, 2, 1 on your page
-     */
+    * Reversed rendered order of layout items, e.g. items 1, 2, 3, 4 in your
+    * markup will display in order 4, 3, 2, 1 on your page
+    */
   .#{settings.$gel-grid-namespace}layout--rev {
     flex-direction: row-reverse;
   }
@@ -194,8 +178,8 @@ $enhanced: true !default;
   }
 
   /**
-     * Align layout items to the vertical centers of each other
-     */
+    * Align layout items to the vertical centers of each other
+    */
   .#{settings.$gel-grid-namespace}layout--middle {
     align-items: center;
   }
@@ -207,8 +191,8 @@ $enhanced: true !default;
   }
 
   /**
-     * Align layout items to the vertical bottoms of each other
-     */
+    * Align layout items to the vertical bottoms of each other
+    */
   .#{settings.$gel-grid-namespace}layout--bottom {
     align-items: flex-end;
   }
@@ -220,8 +204,8 @@ $enhanced: true !default;
   }
 
   /**
-     * Make the layout items fill up from the right hand side
-     */
+    * Make the layout items fill up from the right hand side
+    */
   .#{settings.$gel-grid-namespace}layout--right {
     text-align: sass-tools.flip(right, left);
     justify-content: flex-end;
@@ -234,8 +218,8 @@ $enhanced: true !default;
   }
 
   /**
-     * Make the layout items fill up from the center outward
-     */
+    * Make the layout items fill up from the center outward
+    */
   .#{settings.$gel-grid-namespace}layout--center {
     text-align: center;
     justify-content: center;
@@ -248,8 +232,8 @@ $enhanced: true !default;
   }
 
   /**
-     * Cause layout items to take up a non-explicit amount of width
-     */
+    * Cause layout items to take up a non-explicit amount of width
+    */
   .#{settings.$gel-grid-namespace}layout--auto {
     > .#{settings.$gel-grid-namespace}layout__item {
       width: auto;
@@ -257,10 +241,10 @@ $enhanced: true !default;
   }
 
   /**
-     * Disable the flexbox grid
-     *
-     * 1. Prevents floated layout items from shrinking the layout
-     */
+    * Disable the flexbox grid
+    *
+    * 1. Prevents floated layout items from shrinking the layout
+    */
   .#{settings.$gel-grid-namespace}layout--no-flex {
     min-width: 100%; // [1]
   }
@@ -268,54 +252,48 @@ $enhanced: true !default;
   .#{settings.$gel-grid-namespace}layout--no-flex {
     &,
     > .#{settings.$gel-grid-namespace}layout__item {
-      display: block;
-
-      @if $enhanced {
-        display: inline-block;
-      }
+      display: inline-block;
     }
   }
 
-  @if $enhanced {
-    /**
-         * Force items to be of equal height
-         */
-    .#{settings.$gel-grid-namespace}layout--equal {
-      > .#{settings.$gel-grid-namespace}layout__item {
-        display: flex;
-      }
+  /**
+    * Force items to be of equal height
+    */
+  .#{settings.$gel-grid-namespace}layout--equal {
+    > .#{settings.$gel-grid-namespace}layout__item {
+      display: flex;
     }
+  }
 
-    /**
-         * Allow items to devide the space equally between the number of items
-         */
-    .#{settings.$gel-grid-namespace}layout--fit {
-      > .#{settings.$gel-grid-namespace}layout__item {
-        width: auto;
-        flex: 1 1 auto;
-      }
+  /**
+    * Allow items to devide the space equally between the number of items
+    */
+  .#{settings.$gel-grid-namespace}layout--fit {
+    > .#{settings.$gel-grid-namespace}layout__item {
+      width: auto;
+      flex: 1 1 auto;
     }
+  }
 
-    /**
-         * Align a single grid item to the top
-         */
-    .#{settings.$gel-grid-namespace}layout__item--top {
-      align-self: flex-start;
-    }
+  /**
+    * Align a single grid item to the top
+    */
+  .#{settings.$gel-grid-namespace}layout__item--top {
+    align-self: flex-start;
+  }
 
-    /**
-         * Align a single grid item to the center
-         */
-    .#{settings.$gel-grid-namespace}layout__item--center {
-      align-self: center;
-    }
+  /**
+        * Align a single grid item to the center
+        */
+  .#{settings.$gel-grid-namespace}layout__item--center {
+    align-self: center;
+  }
 
-    /**
-         * Align a single grid item to the bottom
-         */
-    .#{settings.$gel-grid-namespace}layout__item--bottom {
-      align-self: flex-end;
-    }
+  /**
+    * Align a single grid item to the bottom
+    */
+  .#{settings.$gel-grid-namespace}layout__item--bottom {
+    align-self: flex-end;
   }
 }
 
@@ -330,19 +308,17 @@ $enhanced: true !default;
 @mixin gel-output-widths() {
   @include _gel-widths(settings.$gel-grid-columns);
 
-  @if $enhanced {
-    @each $breakpoint in settings.$gel-grid-breakpoints {
-      @include mq.mq($from: '#{settings.$gel-grid-breakpoint-namespace}#{$breakpoint}') {
-        @include _gel-widths(settings.$gel-grid-columns, $breakpoint);
-      }
+  @each $breakpoint in settings.$gel-grid-breakpoints {
+    @include mq.mq($from: '#{settings.$gel-grid-breakpoint-namespace}#{$breakpoint}') {
+      @include _gel-widths(settings.$gel-grid-columns, $breakpoint);
     }
+  }
 
-    @if settings.$gel-grid-1280-toggle-class != null {
-      .#{settings.$gel-grid-1280-toggle-class} {
-        @each $breakpoint in settings.$gel-grid-breakpoints--1280 {
-          @include mq.mq($from: '#{settings.$gel-grid-breakpoint-namespace}#{$breakpoint}') {
-            @include _gel-widths(settings.$gel-grid-columns, $breakpoint);
-          }
+  @if settings.$gel-grid-1280-toggle-class != null {
+    .#{settings.$gel-grid-1280-toggle-class} {
+      @each $breakpoint in settings.$gel-grid-breakpoints--1280 {
+        @include mq.mq($from: '#{settings.$gel-grid-breakpoint-namespace}#{$breakpoint}') {
+          @include _gel-widths(settings.$gel-grid-columns, $breakpoint);
         }
       }
     }

--- a/lib/_tools.scss
+++ b/lib/_tools.scss
@@ -11,7 +11,6 @@
 // define some output control variables
 $core: true !default;
 $enhanced: true !default;
-$fixed: false !default;
 
 // Grid container, used to wrap all grid elements and apply the correct maximum widths
 //
@@ -26,10 +25,6 @@ $fixed: false !default;
     max-width: settings.$gel-grid-max-width-1008;
     #{sass-tools.$padding-right}: sass-tools.$gel-spacing-unit;
     #{sass-tools.$padding-left}: sass-tools.$gel-spacing-unit;
-
-    @if $fixed {
-      width: #{settings.$gel-grid-max-width-1008}; // [1]
-    }
   }
 
   @if $enhanced {
@@ -57,10 +52,6 @@ $fixed: false !default;
 @mixin gel-wrap-1280-breakpoint() {
   @include mq.mq($from: settings.$gel-grid-max-width-1280) {
     max-width: settings.$gel-grid-max-width-1280;
-
-    @if $fixed {
-      width: #{settings.$gel-grid-max-width-1280}; // [1]
-    }
   }
 }
 

--- a/lib/_tools.scss
+++ b/lib/_tools.scss
@@ -9,7 +9,6 @@
 //\*------------------------------------*/
 
 // define some output control variables
-$core: true !default;
 $enhanced: true !default;
 
 // Grid container, used to wrap all grid elements and apply the correct maximum widths
@@ -20,12 +19,10 @@ $enhanced: true !default;
 // @author Shaun Bent
 //
 @mixin gel-wrap() {
-  @if $core {
-    margin: 0 auto;
-    max-width: settings.$gel-grid-max-width-1008;
-    #{sass-tools.$padding-right}: sass-tools.$gel-spacing-unit;
-    #{sass-tools.$padding-left}: sass-tools.$gel-spacing-unit;
-  }
+  margin: 0 auto;
+  max-width: settings.$gel-grid-max-width-1008;
+  #{sass-tools.$padding-right}: sass-tools.$gel-spacing-unit;
+  #{sass-tools.$padding-left}: sass-tools.$gel-spacing-unit;
 
   @if $enhanced {
     @if settings.$gel-grid-enable--box-sizing {
@@ -331,9 +328,7 @@ $enhanced: true !default;
 // @author Shaun Bent
 //
 @mixin gel-output-widths() {
-  @if $core {
-    @include _gel-widths(settings.$gel-grid-columns);
-  }
+  @include _gel-widths(settings.$gel-grid-columns);
 
   @if $enhanced {
     @each $breakpoint in settings.$gel-grid-breakpoints {

--- a/test/__snapshots__/gel-layout-item.test.js.snap
+++ b/test/__snapshots__/gel-layout-item.test.js.snap
@@ -2,11 +2,11 @@
 
 exports[`gel-layout-item() creates a single layout group/row, this wraps individual layout items 1`] = `
 ".gel-layout-item {
-  width: 100%;
   display: inline-block;
   padding-left: 8px;
   text-align: left;
   vertical-align: top;
+  width: 100%;
 }
 @media (min-width: 37.5em) {
   .gel-layout-item {

--- a/test/__snapshots__/gel-layout.test.js.snap
+++ b/test/__snapshots__/gel-layout.test.js.snap
@@ -3,15 +3,15 @@
 exports[`gel-layout() creates a layout to wrap around items 1`] = `
 ".gel-layout {
   direction: ltr;
-  list-style: none;
-  text-align: left;
   display: flex;
   flex-flow: row wrap;
   flex-grow: 1;
+  list-style: none;
   margin-right: 0;
   margin-left: -8px;
   padding-right: 0;
   padding-left: 0;
+  text-align: left;
 }
 @media (min-width: 37.5em) {
   .gel-layout {
@@ -23,15 +23,15 @@ exports[`gel-layout() creates a layout to wrap around items 1`] = `
 exports[`gel-layout() creates a layout to wrap around items, with an optional whitespace adjustment 1`] = `
 ".gel-layout {
   direction: ltr;
-  list-style: none;
-  text-align: left;
   display: flex;
   flex-flow: row wrap;
   flex-grow: 1;
+  list-style: none;
   margin-right: 0;
   margin-left: -8px;
   padding-right: 0;
   padding-left: 0;
+  text-align: left;
   letter-spacing: -0.31em;
   text-rendering: optimizespeed;
 }

--- a/test/__snapshots__/gel-output-grid.test.js.snap
+++ b/test/__snapshots__/gel-output-grid.test.js.snap
@@ -2,8 +2,8 @@
 
 exports[`gel-output-grid() generates a collection of generic grid classes 1`] = `
 "/**
-   * Grid containing element
-   */
+  * Grid containing element
+  */
 .gel-wrap {
   margin: 0 auto;
   max-width: 1008px;
@@ -23,19 +23,19 @@ exports[`gel-output-grid() generates a collection of generic grid classes 1`] = 
 }
 
 /**
-   * A grid row
-   */
+  * A grid row
+  */
 .gel-layout {
   direction: ltr;
-  list-style: none;
-  text-align: left;
   display: flex;
   flex-flow: row wrap;
   flex-grow: 1;
+  list-style: none;
   margin-right: 0;
   margin-left: -8px;
   padding-right: 0;
   padding-left: 0;
+  text-align: left;
 }
 @media (min-width: 37.5em) {
   .gel-layout {
@@ -44,14 +44,14 @@ exports[`gel-output-grid() generates a collection of generic grid classes 1`] = 
 }
 
 /**
-   * A single grid item
-   */
+  * A single grid item
+  */
 .gel-layout__item {
-  width: 100%;
   display: inline-block;
   padding-left: 8px;
   text-align: left;
   vertical-align: top;
+  width: 100%;
 }
 @media (min-width: 37.5em) {
   .gel-layout__item {
@@ -60,8 +60,8 @@ exports[`gel-output-grid() generates a collection of generic grid classes 1`] = 
 }
 
 /**
-   * Layouts with no gutters.
-   */
+  * Layouts with no gutters.
+  */
 .gel-layout--flush {
   margin-left: 0;
 }
@@ -71,9 +71,9 @@ exports[`gel-output-grid() generates a collection of generic grid classes 1`] = 
 }
 
 /**
-   * Reversed rendered order of layout items, e.g. items 1, 2, 3, 4 in your
-   * markup will display in order 4, 3, 2, 1 on your page
-   */
+  * Reversed rendered order of layout items, e.g. items 1, 2, 3, 4 in your
+  * markup will display in order 4, 3, 2, 1 on your page
+  */
 .gel-layout--rev {
   flex-direction: row-reverse;
 }
@@ -89,8 +89,8 @@ exports[`gel-output-grid() generates a collection of generic grid classes 1`] = 
 }
 
 /**
-   * Align layout items to the vertical centers of each other
-   */
+  * Align layout items to the vertical centers of each other
+  */
 .gel-layout--middle {
   align-items: center;
 }
@@ -100,8 +100,8 @@ exports[`gel-output-grid() generates a collection of generic grid classes 1`] = 
 }
 
 /**
-   * Align layout items to the vertical bottoms of each other
-   */
+  * Align layout items to the vertical bottoms of each other
+  */
 .gel-layout--bottom {
   align-items: flex-end;
 }
@@ -111,8 +111,8 @@ exports[`gel-output-grid() generates a collection of generic grid classes 1`] = 
 }
 
 /**
-   * Make the layout items fill up from the right hand side
-   */
+  * Make the layout items fill up from the right hand side
+  */
 .gel-layout--right {
   text-align: right;
   justify-content: flex-end;
@@ -123,8 +123,8 @@ exports[`gel-output-grid() generates a collection of generic grid classes 1`] = 
 }
 
 /**
-   * Make the layout items fill up from the center outward
-   */
+  * Make the layout items fill up from the center outward
+  */
 .gel-layout--center {
   text-align: center;
   justify-content: center;
@@ -135,59 +135,58 @@ exports[`gel-output-grid() generates a collection of generic grid classes 1`] = 
 }
 
 /**
-   * Cause layout items to take up a non-explicit amount of width
-   */
+  * Cause layout items to take up a non-explicit amount of width
+  */
 .gel-layout--auto > .gel-layout__item {
   width: auto;
 }
 
 /**
-   * Disable the flexbox grid
-   *
-   * 1. Prevents floated layout items from shrinking the layout
-   */
+  * Disable the flexbox grid
+  *
+  * 1. Prevents floated layout items from shrinking the layout
+  */
 .gel-layout--no-flex {
   min-width: 100%;
 }
 
 .gel-layout--no-flex,
 .gel-layout--no-flex > .gel-layout__item {
-  display: block;
   display: inline-block;
 }
 
 /**
-     * Force items to be of equal height
-     */
+  * Force items to be of equal height
+  */
 .gel-layout--equal > .gel-layout__item {
   display: flex;
 }
 
 /**
-     * Allow items to devide the space equally between the number of items
-     */
+  * Allow items to devide the space equally between the number of items
+  */
 .gel-layout--fit > .gel-layout__item {
   width: auto;
   flex: 1 1 auto;
 }
 
 /**
-     * Align a single grid item to the top
-     */
+  * Align a single grid item to the top
+  */
 .gel-layout__item--top {
   align-self: flex-start;
 }
 
 /**
-     * Align a single grid item to the center
-     */
+      * Align a single grid item to the center
+      */
 .gel-layout__item--center {
   align-self: center;
 }
 
 /**
-     * Align a single grid item to the bottom
-     */
+  * Align a single grid item to the bottom
+  */
 .gel-layout__item--bottom {
   align-self: flex-end;
 }
@@ -814,14 +813,14 @@ exports[`gel-output-grid() generates a collection of generic grid classes 1`] = 
 
 exports[`gel-output-grid() generates a collection of generic grid classes, with all options enabled 1`] = `
 "/**
-   * Grid containing element
-   */
+  * Grid containing element
+  */
 .gel-wrap {
+  box-sizing: border-box;
   margin: 0 auto;
   max-width: 1008px;
   padding-right: 8px;
   padding-left: 8px;
-  box-sizing: border-box;
 }
 @media (min-width: 25em) {
   .gel-wrap {
@@ -836,19 +835,19 @@ exports[`gel-output-grid() generates a collection of generic grid classes, with 
 }
 
 /**
-   * A grid row
-   */
+  * A grid row
+  */
 .gel-layout {
   direction: ltr;
-  list-style: none;
-  text-align: left;
   display: flex;
   flex-flow: row wrap;
   flex-grow: 1;
+  list-style: none;
   margin-right: 0;
   margin-left: -8px;
   padding-right: 0;
   padding-left: 0;
+  text-align: left;
   letter-spacing: -0.31em;
   text-rendering: optimizespeed;
 }
@@ -863,15 +862,15 @@ exports[`gel-output-grid() generates a collection of generic grid classes, with 
 }
 
 /**
-   * A single grid item
-   */
+  * A single grid item
+  */
 .gel-layout__item {
-  width: 100%;
+  box-sizing: border-box;
   display: inline-block;
   padding-left: 8px;
   text-align: left;
   vertical-align: top;
-  box-sizing: border-box;
+  width: 100%;
   letter-spacing: normal;
   text-rendering: auto;
   word-spacing: normal;
@@ -883,8 +882,8 @@ exports[`gel-output-grid() generates a collection of generic grid classes, with 
 }
 
 /**
-   * Layouts with no gutters.
-   */
+  * Layouts with no gutters.
+  */
 .gel-layout--flush {
   margin-left: 0;
 }
@@ -894,9 +893,9 @@ exports[`gel-output-grid() generates a collection of generic grid classes, with 
 }
 
 /**
-   * Reversed rendered order of layout items, e.g. items 1, 2, 3, 4 in your
-   * markup will display in order 4, 3, 2, 1 on your page
-   */
+  * Reversed rendered order of layout items, e.g. items 1, 2, 3, 4 in your
+  * markup will display in order 4, 3, 2, 1 on your page
+  */
 .gel-layout--rev {
   flex-direction: row-reverse;
 }
@@ -912,8 +911,8 @@ exports[`gel-output-grid() generates a collection of generic grid classes, with 
 }
 
 /**
-   * Align layout items to the vertical centers of each other
-   */
+  * Align layout items to the vertical centers of each other
+  */
 .gel-layout--middle {
   align-items: center;
 }
@@ -923,8 +922,8 @@ exports[`gel-output-grid() generates a collection of generic grid classes, with 
 }
 
 /**
-   * Align layout items to the vertical bottoms of each other
-   */
+  * Align layout items to the vertical bottoms of each other
+  */
 .gel-layout--bottom {
   align-items: flex-end;
 }
@@ -934,8 +933,8 @@ exports[`gel-output-grid() generates a collection of generic grid classes, with 
 }
 
 /**
-   * Make the layout items fill up from the right hand side
-   */
+  * Make the layout items fill up from the right hand side
+  */
 .gel-layout--right {
   text-align: right;
   justify-content: flex-end;
@@ -946,8 +945,8 @@ exports[`gel-output-grid() generates a collection of generic grid classes, with 
 }
 
 /**
-   * Make the layout items fill up from the center outward
-   */
+  * Make the layout items fill up from the center outward
+  */
 .gel-layout--center {
   text-align: center;
   justify-content: center;
@@ -958,59 +957,58 @@ exports[`gel-output-grid() generates a collection of generic grid classes, with 
 }
 
 /**
-   * Cause layout items to take up a non-explicit amount of width
-   */
+  * Cause layout items to take up a non-explicit amount of width
+  */
 .gel-layout--auto > .gel-layout__item {
   width: auto;
 }
 
 /**
-   * Disable the flexbox grid
-   *
-   * 1. Prevents floated layout items from shrinking the layout
-   */
+  * Disable the flexbox grid
+  *
+  * 1. Prevents floated layout items from shrinking the layout
+  */
 .gel-layout--no-flex {
   min-width: 100%;
 }
 
 .gel-layout--no-flex,
 .gel-layout--no-flex > .gel-layout__item {
-  display: block;
   display: inline-block;
 }
 
 /**
-     * Force items to be of equal height
-     */
+  * Force items to be of equal height
+  */
 .gel-layout--equal > .gel-layout__item {
   display: flex;
 }
 
 /**
-     * Allow items to devide the space equally between the number of items
-     */
+  * Allow items to devide the space equally between the number of items
+  */
 .gel-layout--fit > .gel-layout__item {
   width: auto;
   flex: 1 1 auto;
 }
 
 /**
-     * Align a single grid item to the top
-     */
+  * Align a single grid item to the top
+  */
 .gel-layout__item--top {
   align-self: flex-start;
 }
 
 /**
-     * Align a single grid item to the center
-     */
+      * Align a single grid item to the center
+      */
 .gel-layout__item--center {
   align-self: center;
 }
 
 /**
-     * Align a single grid item to the bottom
-     */
+  * Align a single grid item to the bottom
+  */
 .gel-layout__item--bottom {
   align-self: flex-end;
 }

--- a/test/__snapshots__/gel-wrap.test.js.snap
+++ b/test/__snapshots__/gel-wrap.test.js.snap
@@ -2,11 +2,11 @@
 
 exports[`gel-wrap() adds box-sizing properties when box-sizing is enabled 1`] = `
 ".gel-wrap {
+  box-sizing: border-box;
   margin: 0 auto;
   max-width: 1008px;
   padding-right: 8px;
   padding-left: 8px;
-  box-sizing: border-box;
 }
 @media (min-width: 25em) {
   .gel-wrap {


### PR DESCRIPTION
## Description
These three variables allowed for control of the output, where `core` functionality could be separated out from `enhanced` functionality (for more advanced browsers) and for Internet Explorer (`fixed`).

As browsers have moved on significantly since this approach was adopted it is considered a good time to remove this functionality.