### PR TITLE
fix: Remove global switch

### DIFF
--- a/codebuild/releasespec.yml
+++ b/codebuild/releasespec.yml
@@ -8,8 +8,8 @@ phases:
   install:
     on-failure: ABORT
     commands:
-      - npm config set -g '//registry.npmjs.org/:_authToken' $NPM_TOKEN
-      - npm config set -g ignore-scripts true
+      - npm config set '//registry.npmjs.org/:_authToken' $NPM_TOKEN
+      - npm config set ignore-scripts true
       - npm ci
 
   build:


### PR DESCRIPTION
Removes the npm global switch, it does not break anything - but is not required