### PR TITLE
chore: Add `npm audit` to CodeBuild jobs

### DIFF
--- a/codebuild/buildspec.yml
+++ b/codebuild/buildspec.yml
@@ -11,6 +11,7 @@ phases:
       - npm config set '//registry.npmjs.org/:_authToken' $NPM_TOKEN
       - npm config set ignore-scripts true
       - npm ci
+      - npm audit
 
   build:
     on-failure: ABORT

--- a/codebuild/releasespec.yml
+++ b/codebuild/releasespec.yml
@@ -11,6 +11,7 @@ phases:
       - npm config set '//registry.npmjs.org/:_authToken' $NPM_TOKEN
       - npm config set ignore-scripts true
       - npm ci
+      - npm audit
 
   build:
     on-failure: ABORT


### PR DESCRIPTION
## Description
In light of the recent supply chain attacks in npm we've been requested to tighten up security and oversight of the packages we use.

`npm audit` is being added to the build process to ensure we don't release any ccode relying on insecure packages.