### PR TITLE
chore: Avoid pre and post scripts

### DIFF
--- a/codebuild/releasespec.yml
+++ b/codebuild/releasespec.yml
@@ -18,7 +18,7 @@ phases:
     commands:
       - npm run build
       - npm test
- 
+
   post_build:
     on-failure: ABORT
     commands:

--- a/demo/gulpfile.js
+++ b/demo/gulpfile.js
@@ -10,40 +10,37 @@ var autoprefixerOptions = { browsers: supportedBrowsers };
 
 // cssnano config
 var nanoOptions = {
-    autoprefixer: { browsers: supportedBrowsers },
-    convertValues: { length: false, boolean: false },
-    mergeRules: false
+  autoprefixer: { browsers: supportedBrowsers },
+  convertValues: { length: false, boolean: false },
+  mergeRules: false,
 };
 
 // compile the Sass
-gulp.task('sass', function() {
-    return gulp.src('src/assets/sass/*.scss')
-        .pipe(
-            plugins.sass()
-                .on('error', plugins.sass.logError)
-        )
-        .pipe(plugins.autoprefixer(autoprefixerOptions))
-        .pipe(plugins.cssnano(nanoOptions))
-        .pipe(gulp.dest('src/assets/css'));
+gulp.task('sass', function () {
+  return gulp
+    .src('src/assets/sass/*.scss')
+    .pipe(plugins.sass().on('error', plugins.sass.logError))
+    .pipe(plugins.autoprefixer(autoprefixerOptions))
+    .pipe(plugins.cssnano(nanoOptions))
+    .pipe(gulp.dest('src/assets/css'));
 });
 
 // watch files for changes
-gulp.task('watch', function() {
-    gulp.watch('src/assets/sass/**/*.scss', ['sass']);
-    gulp.watch(['src/index.html', 'src/assets/images/**/*'], ['copy']);
+gulp.task('watch', function () {
+  gulp.watch('src/assets/sass/**/*.scss', ['sass']);
+  gulp.watch(['src/index.html', 'src/assets/images/**/*'], ['copy']);
 });
 
 gulp.task('copy', function () {
-    gulp.src(['!./src/assets/sass/**/*', '!./src/bower_components/**/*', './src/**/*'])
-        .pipe(gulp.dest('./dist/'));
+  gulp
+    .src(['!./src/assets/sass/**/*', '!./src/bower_components/**/*', './src/**/*'])
+    .pipe(gulp.dest('./dist/'));
 });
 
 // default task
 gulp.task('default', ['sass', 'copy', 'watch']);
 
 // deploy task
-gulp.task('deploy', ['sass', 'copy'], function() {
-    return gulp.src('./dist/**/*')
-        .pipe(plugins.ghPages());
-        
+gulp.task('deploy', ['sass', 'copy'], function () {
+  return gulp.src('./dist/**/*').pipe(plugins.ghPages());
 });

--- a/demo/src/assets/sass/_base.box-sizing.scss
+++ b/demo/src/assets/sass/_base.box-sizing.scss
@@ -9,11 +9,11 @@
  * http://www.paulirish.com/2012/box-sizing-border-box-ftw/
  */
 html {
-    box-sizing: border-box;
+  box-sizing: border-box;
 }
 
 *,
 *:before,
 *:after {
-    box-sizing: inherit;
+  box-sizing: inherit;
 }

--- a/demo/src/assets/sass/_base.normalize.scss
+++ b/demo/src/assets/sass/_base.normalize.scss
@@ -331,8 +331,8 @@ input {
  * 2. Remove excess padding in IE 8/9/10.
  */
 
-input[type="checkbox"],
-input[type="radio"] {
+input[type='checkbox'],
+input[type='radio'] {
   box-sizing: border-box; /* 1 */
   padding: 0; /* 2 */
 }
@@ -343,8 +343,8 @@ input[type="radio"] {
  * decrement button to change from `default` to `text`.
  */
 
-input[type="number"]::-webkit-inner-spin-button,
-input[type="number"]::-webkit-outer-spin-button {
+input[type='number']::-webkit-inner-spin-button,
+input[type='number']::-webkit-outer-spin-button {
   height: auto;
 }
 
@@ -354,7 +354,7 @@ input[type="number"]::-webkit-outer-spin-button {
  *    (include `-moz` to future-proof).
  */
 
-input[type="search"] {
+input[type='search'] {
   -webkit-appearance: textfield; /* 1 */
   -moz-box-sizing: content-box;
   -webkit-box-sizing: content-box; /* 2 */
@@ -367,8 +367,8 @@ input[type="search"] {
  * padding (and `textfield` appearance).
  */
 
-input[type="search"]::-webkit-search-cancel-button,
-input[type="search"]::-webkit-search-decoration {
+input[type='search']::-webkit-search-cancel-button,
+input[type='search']::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 

--- a/demo/src/assets/sass/_base.page.scss
+++ b/demo/src/assets/sass/_base.page.scss
@@ -3,21 +3,21 @@
 \*------------------------------------*/
 
 html {
-    font-family: Helvetica, Arial, Sans-serif;
-    color: $gel-color--tundora;
+  font-family: Helvetica, Arial, Sans-serif;
+  color: $gel-color--tundora;
 }
 
 a,
 a:visited {
-    font-weight: bold;
-    text-decoration: underline;
-    color: $gel-color--tundora;
-    transition: color 0.2s ease-out;
+  font-weight: bold;
+  text-decoration: underline;
+  color: $gel-color--tundora;
+  transition: color 0.2s ease-out;
 }
 
 a:focus,
 a:hover,
 a:active {
-    text-decoration: underline;
-    color: $gel-color--orange;
+  text-decoration: underline;
+  color: $gel-color--orange;
 }

--- a/demo/src/assets/sass/_base.reset.scss
+++ b/demo/src/assets/sass/_base.reset.scss
@@ -7,23 +7,43 @@
  * margins from certain elements.
  */
 body,
-h1, h2, h3, h4, h5, h6,
-p, blockquote, pre,
-dl, dd, ol, ul,
-form, fieldset, legend,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+blockquote,
+pre,
+dl,
+dd,
+ol,
+ul,
+form,
+fieldset,
+legend,
 figure,
-table, th, td, caption,
+table,
+th,
+td,
+caption,
 hr {
-    margin:  0;
-    padding: 0;
+  margin: 0;
+  padding: 0;
 }
 
 /**
  * Remove the default font-weight so we can control this with our
  * typography classes
  */
-h1, h2, h3, h4, h5, h6 {
-    font-weight: normal;
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-weight: normal;
 }
 
 /**
@@ -31,7 +51,7 @@ h1, h2, h3, h4, h5, h6 {
  */
 abbr[title],
 dfn[title] {
-    cursor: help;
+  cursor: help;
 }
 
 /**
@@ -39,12 +59,12 @@ dfn[title] {
  */
 u,
 ins {
-    text-decoration: none;
+  text-decoration: none;
 }
 
 /**
  * Apply faux underlines to inserted text via `border-bottom`.
  */
 ins {
-    border-bottom: 1px solid;
+  border-bottom: 1px solid;
 }

--- a/demo/src/assets/sass/_component.demo-controls.scss
+++ b/demo/src/assets/sass/_component.demo-controls.scss
@@ -2,58 +2,58 @@
     # DEMO CONTROLS
 \*------------------------------------*/
 
- .gel-c-demo-controls {
-    position: relative;
+.gel-c-demo-controls {
+  position: relative;
 
-    margin-top: 0;
-    margin-right: -$gel-spacing-unit;
-    margin-left: -$gel-spacing-unit;
-    padding: $gel-spacing-unit;
+  margin-top: 0;
+  margin-right: -$gel-spacing-unit;
+  margin-left: -$gel-spacing-unit;
+  padding: $gel-spacing-unit;
 
-    background-color: $gel-color--orange;
-    color: $gel-color--white;
+  background-color: $gel-color--orange;
+  color: $gel-color--white;
 
-    @if $enhanced {
-        @include mq($from: gel-bp-s) {
-            margin-right: double(-$gel-spacing-unit);
-            margin-left: double(-$gel-spacing-unit);
-            padding: double($gel-spacing-unit);
-        }
-
-        @include mq($from: gel-bp-l) {
-            margin: 0 0 quadruple($gel-spacing-unit);
-        }
+  @if $enhanced {
+    @include mq($from: gel-bp-s) {
+      margin-right: double(-$gel-spacing-unit);
+      margin-left: double(-$gel-spacing-unit);
+      padding: double($gel-spacing-unit);
     }
+
+    @include mq($from: gel-bp-l) {
+      margin: 0 0 quadruple($gel-spacing-unit);
+    }
+  }
 }
 
 .gel-c-demo-controls__options {
-    margin-top: $gel-spacing-unit;
+  margin-top: $gel-spacing-unit;
 
-    @if $enhanced {
-        @include mq($from: gel-bp-m) {
-            margin-bottom: 0;
-            position: absolute;
-            bottom: double($gel-spacing-unit);
-            #{$right}: double($gel-spacing-unit);
-        }
+  @if $enhanced {
+    @include mq($from: gel-bp-m) {
+      margin-bottom: 0;
+      position: absolute;
+      bottom: double($gel-spacing-unit);
+      #{$right}: double($gel-spacing-unit);
     }
+  }
 }
 
 .gel-c-demo-controls__option {
-    padding: 0;
-    border: 0;
-    outline: 0;
+  padding: 0;
+  border: 0;
+  outline: 0;
 
-    color: #fff;
+  color: #fff;
 
-    background: none;
+  background: none;
 
-    &:focus,
-    &:hover {
-        text-decoration: underline;
-    }
+  &:focus,
+  &:hover {
+    text-decoration: underline;
+  }
 }
 
 .gel-c-demo-controls__option + .gel-c-demo-controls__option {
-    #{$margin-left}: $gel-spacing-unit;
+  #{$margin-left}: $gel-spacing-unit;
 }

--- a/demo/src/assets/sass/_component.demo-header.scss
+++ b/demo/src/assets/sass/_component.demo-header.scss
@@ -3,82 +3,82 @@
 \*------------------------------------*/
 
 .gel-c-demo-header {
-    margin-bottom: double($gel-spacing-unit);
+  margin-bottom: double($gel-spacing-unit);
 }
 
 .gel-c-demo-header__github-link {
-    display: block;
-    margin: $gel-spacing-unit 0;
+  display: block;
+  margin: $gel-spacing-unit 0;
 
-    object {
-        max-width: 72px;
-        vertical-align: middle;
-    }
+  object {
+    max-width: 72px;
+    vertical-align: middle;
+  }
 }
 
 .gel-c-demo-header__banner {
-    border-top: 1px solid $gel-color--alto;
-	border-bottom: 1px solid $gel-color--alto;
-    padding: $gel-alt-spacing-unit 0;
+  border-top: 1px solid $gel-color--alto;
+  border-bottom: 1px solid $gel-color--alto;
+  padding: $gel-alt-spacing-unit 0;
 }
 
 .gel-c-demo-header__brand {
-    display: block;
-    margin-bottom: $gel-alt-spacing-unit;
+  display: block;
+  margin-bottom: $gel-alt-spacing-unit;
 
-    @if $enhanced {
-        @include mq($from: 460px) {
-            float: flip(left, right);
-            margin-bottom: 0;
-            padding: halve($gel-alt-spacing-unit) 0;
-        }
+  @if $enhanced {
+    @include mq($from: 460px) {
+      float: flip(left, right);
+      margin-bottom: 0;
+      padding: halve($gel-alt-spacing-unit) 0;
     }
+  }
 }
 
 .gel-c-demo-header__brand-logo {
-    position: relative;
-    display: inline-block;
+  position: relative;
+  display: inline-block;
+  vertical-align: middle;
+
+  &:active {
+    top: 1px;
+  }
+
+  svg {
     vertical-align: middle;
-
-    &:active {
-        top: 1px;
-    }
-
-    svg {
-        vertical-align: middle;
-    }
+  }
 }
 
 .gel-c-demo-header__brand-beta {
-    padding: 1px halve($gel-spacing-unit);
+  padding: 1px halve($gel-spacing-unit);
 
-    font-style: normal;
-    font-weight: bold;
+  font-style: normal;
+  font-weight: bold;
 
-    color: $gel-color--white;
-    background: $gel-color--orange;
+  color: $gel-color--white;
+  background: $gel-color--orange;
 
-    vertical-align: top;
+  vertical-align: top;
 }
 
 .gel-c-demo-header__banner-button {
-    display: block;
-    width: 100%;
+  display: block;
+  width: 100%;
 
-    @if $enhanced {
-        @include mq($from: 460px) {
-            float: flip(right, left);
-            width: auto;
-        }
+  @if $enhanced {
+    @include mq($from: 460px) {
+      float: flip(right, left);
+      width: auto;
     }
+  }
 }
 
 .gel-c-demo-header__intro {
-    margin: double($gel-spacing-unit) 0;
+  margin: double($gel-spacing-unit) 0;
 
-    @if $enhanced {
-        @include mq($from: gel-bp-l) {
-            margin: quadruple($gel-spacing-unit) 0;
-        }
+  @if $enhanced {
+    @include mq($from: gel-bp-l) {
+      margin: quadruple($gel-spacing-unit) 0;
     }
+  }
 }

--- a/demo/src/assets/sass/_component.grid-controls.scss
+++ b/demo/src/assets/sass/_component.grid-controls.scss
@@ -6,68 +6,71 @@
 * Change the group name based on the current media-query
 */
 .gel-c-grid-controls__group-name {
-   &:after {
-       content: flip('Group 1 - Extra Small (0 - 399px)', 'Group 1 - Extra Small \200F(0 - 399px)');
-   }
+  &:after {
+    content: flip('Group 1 - Extra Small (0 - 399px)', 'Group 1 - Extra Small \200F(0 - 399px)');
+  }
 
-   @if $enhanced {
-       @include mq($from: gel-bp-s) {
-           &:after {
-               content: flip('Group 2 - Small (400px - 599px)', 'Group 2 - Small \200F(400px - 599px)');
-           }
-       }
+  @if $enhanced {
+    @include mq($from: gel-bp-s) {
+      &:after {
+        content: flip('Group 2 - Small (400px - 599px)', 'Group 2 - Small \200F(400px - 599px)');
+      }
+    }
 
-       @include mq($from: gel-bp-m) {
-           &:after {
-               content: flip('Group 3 - Medium (600px - 899px)', 'Group 3 - Medium \200F(600px - 899px)');
-           }
-       }
+    @include mq($from: gel-bp-m) {
+      &:after {
+        content: flip('Group 3 - Medium (600px - 899px)', 'Group 3 - Medium \200F(600px - 899px)');
+      }
+    }
 
-       @include mq($from: gel-bp-l) {
-           &:after {
-               content: flip('Group 4 - Large (900px)', 'Group 4 - Large \200F(900px)');
-           }
-       }
+    @include mq($from: gel-bp-l) {
+      &:after {
+        content: flip('Group 4 - Large (900px)', 'Group 4 - Large \200F(900px)');
+      }
+    }
 
-       @include mq($from: gel-bp-xl) {
-           &:after {
-               content: flip('Group 5 - Extra Large (1008px)', 'Group 5 - Extra Large \200F(1008px)');
-           }
-       }
+    @include mq($from: gel-bp-xl) {
+      &:after {
+        content: flip('Group 5 - Extra Large (1008px)', 'Group 5 - Extra Large \200F(1008px)');
+      }
+    }
 
-       @include mq($from: gel-bp-xxl) {
-           &:after {
-               content: flip('Group 6 - Extra Extra Large (1280px)', 'Group 6 - Extra Extra Large \200F(1280px)');
-           }
-       }
-   }
+    @include mq($from: gel-bp-xxl) {
+      &:after {
+        content: flip(
+          'Group 6 - Extra Extra Large (1280px)',
+          'Group 6 - Extra Extra Large \200F(1280px)'
+        );
+      }
+    }
+  }
 }
 
 /**
 * Change the margin's and gutter's based on the breakpoint
 */
 .gel-c-grid-controls__margin-gutter-size {
-   &:after {
-       content: 'Margins: 8px | Gutters: 8px';
-   }
+  &:after {
+    content: 'Margins: 8px | Gutters: 8px';
+  }
 
-   @if $enhanced {
-       @include mq($from: gel-bp-s) {
-           &:after {
-               content: 'Margins: 16px | Gutters: 8px';
-           }
-       }
+  @if $enhanced {
+    @include mq($from: gel-bp-s) {
+      &:after {
+        content: 'Margins: 16px | Gutters: 8px';
+      }
+    }
 
-       @include mq($from: gel-bp-m) {
-           &:after {
-               content: 'Margins: 16px | Gutters: 16px  |  For layouts a 900px breakpoint can also be used.';
-           }
-       }
+    @include mq($from: gel-bp-m) {
+      &:after {
+        content: 'Margins: 16px | Gutters: 16px  |  For layouts a 900px breakpoint can also be used.';
+      }
+    }
 
-       @include mq($from: gel-bp-l) {
-           &:after {
-               content: 'Margins: 16px | Gutters: 16px';
-           }
-       }
-   }
+    @include mq($from: gel-bp-l) {
+      &:after {
+        content: 'Margins: 16px | Gutters: 16px';
+      }
+    }
+  }
 }

--- a/demo/src/assets/sass/_component.grid-demo.scss
+++ b/demo/src/assets/sass/_component.grid-demo.scss
@@ -3,74 +3,74 @@
 \*------------------------------------*/
 
 .gel-c-grid-demo-section {
-    margin-top: double($gel-spacing-unit);
-    border-top: 1px solid $gel-color--alto;
-    padding-top: double($gel-spacing-unit);
+  margin-top: double($gel-spacing-unit);
+  border-top: 1px solid $gel-color--alto;
+  padding-top: double($gel-spacing-unit);
 }
 
 .gel-c-grid-demo__summary {
-    margin-top: halve($gel-spacing-unit);
-    color: $gel-color--cod-gray;
+  margin-top: halve($gel-spacing-unit);
+  color: $gel-color--cod-gray;
 }
 
 /**
  * A placeholder element to demostrate grid sizing
  */
 .gel-c-grid-demo-item {
-    width: 100%;
-    padding: $gel-spacing-unit;
+  width: 100%;
+  padding: $gel-spacing-unit;
 
-    background-color: #d4e7eb;
-    color: $gel-color--black;
+  background-color: #d4e7eb;
+  color: $gel-color--black;
 
-    @if $enhanced {
-        @include mq($from: gel-bp-s) {
-            padding: double($gel-spacing-unit);
-        }
+  @if $enhanced {
+    @include mq($from: gel-bp-s) {
+      padding: double($gel-spacing-unit);
     }
+  }
 }
 
 .gel-c-grid-demo-item--fill {
-    background: repeating-linear-gradient(180deg, #d4e7eb, #d4e7eb 8px, #aec4cc 8px, #aec4cc 16px);
+  background: repeating-linear-gradient(180deg, #d4e7eb, #d4e7eb 8px, #aec4cc 8px, #aec4cc 16px);
 }
 
 .gel-c-grid-demo-item--auto {
-    height: auto;
+  height: auto;
 }
 
 .gel-c-grid-demo-item--large {
-    height: 144px;
+  height: 144px;
 }
 
 /**
  * A basic GEL Promo pattern
  */
 .gel-c-grid-demo-promo {
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-    -webkit-flex: 1 1 auto;
-    -ms-flex: 1 1 auto;
-    flex: 1 1 auto;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
 }
 
 .gel-c-grid-demo-promo__image {
-    -webkit-flex: 1 1 auto;
-    -ms-flex: 1 1 auto;
-    flex: 1 1 auto;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
 }
 
 .gel-c-grid-demo-promo__body {
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-    -webkit-flex-flow: column wrap;
-    -ms-flex-flow: column wrap;
-    flex-flow: column wrap;
-    -webkit-flex: 1 1 auto;
-    -ms-flex: 1 1 auto;
-    flex: 1 1 auto;
-    -webkit-justify-content: space-between;
-    -moz-justify-content: space-between;
-    justify-content: space-between;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-flow: column wrap;
+  -ms-flex-flow: column wrap;
+  flex-flow: column wrap;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  -webkit-justify-content: space-between;
+  -moz-justify-content: space-between;
+  justify-content: space-between;
 }

--- a/demo/src/assets/sass/_object.button.scss
+++ b/demo/src/assets/sass/_object.button.scss
@@ -1,42 +1,42 @@
 .gel-o-button,
 .gel-o-button:visited {
-    position: relative;
+  position: relative;
 
-    display: inline-block;
+  display: inline-block;
 
-    margin: 0;
-    border: 0;
-    border: 1px solid $gel-color--tundora;
-    padding: double($gel-spacing-unit);
+  margin: 0;
+  border: 0;
+  border: 1px solid $gel-color--tundora;
+  padding: double($gel-spacing-unit);
 
-    color: $gel-color--white;
-    text-align: center;
-    text-decoration: none;
-    line-height: 1.2;
+  color: $gel-color--white;
+  text-align: center;
+  text-decoration: none;
+  line-height: 1.2;
 
-    background-color: $gel-color--tundora;
-    appearance: none;
-    cursor: pointer;
+  background-color: $gel-color--tundora;
+  appearance: none;
+  cursor: pointer;
 
-    @if $enhanced {
-        @include mq($from: gel-bp-xs) {
-            min-width: 190px;
-        }
+  @if $enhanced {
+    @include mq($from: gel-bp-xs) {
+      min-width: 190px;
     }
+  }
 
-    &:focus,
-    &:hover {
-        text-decoration: underline;
-        background-color: #121212;
-    }
+  &:focus,
+  &:hover {
+    text-decoration: underline;
+    background-color: #121212;
+  }
 
-    &:active {
-        top: 1px;
-        background-color: $gel-color--orange;
-        border-color: $gel-color--orange;
-    }
+  &:active {
+    top: 1px;
+    background-color: $gel-color--orange;
+    border-color: $gel-color--orange;
+  }
 
-    /*.gel-icon--inline {
+  /*.gel-icon--inline {
         margin-right:$gel-spacing-unit;
     }*/
 }
@@ -45,16 +45,16 @@
  * Clear button
  */
 .gel-o-button--clear {
+  background-color: transparent;
+  color: $gel-color--tundora;
+
+  &:focus,
+  &:hover {
     background-color: transparent;
-    color: $gel-color--tundora;
+    border-color: $gel-color--tundora;
+  }
 
-    &:focus,
-    &:hover {
-        background-color: transparent;
-        border-color: $gel-color--tundora;
-    }
-
-    &:active {
-        background-color: transparent;
-    }
+  &:active {
+    background-color: transparent;
+  }
 }

--- a/demo/src/assets/sass/_utilities.float.scss
+++ b/demo/src/assets/sass/_utilities.float.scss
@@ -5,34 +5,34 @@
 $gs-display-switch-breakpoint-names: $gel-breakpoint-names !default;
 
 @mixin floats($suffix: null) {
-    $breakpoint-suffix: '';
+  $breakpoint-suffix: '';
 
-    @if $suffix != null {
-        $breakpoint-suffix: \@#{$suffix};
-    }
+  @if $suffix != null {
+    $breakpoint-suffix: \@#{$suffix};
+  }
 
-    .gs-u-fl#{$breakpoint-suffix} {
-        float: left !important;
-    }
+  .gs-u-fl#{$breakpoint-suffix} {
+    float: left !important;
+  }
 
-    .gs-u-fr#{$breakpoint-suffix} {
-        float: right !important;
-    }
+  .gs-u-fr#{$breakpoint-suffix} {
+    float: right !important;
+  }
 
-    .gs-u-fn#{$breakpoint-suffix} {
-        float: none !important;
-    }
+  .gs-u-fn#{$breakpoint-suffix} {
+    float: none !important;
+  }
 }
 
 // Output the unsuffixed version
 @include floats();
 
 @if $enhanced {
-    @each $breakpoint in $gs-display-switch-breakpoint-names {
-        $breakpoint-name: nth($breakpoint, 1);
+  @each $breakpoint in $gs-display-switch-breakpoint-names {
+    $breakpoint-name: nth($breakpoint, 1);
 
-        @include mq($from: '#{$gel-grid-breakpoint-namespace}#{$breakpoint}') {
-            @include floats($breakpoint-name);
-        }
+    @include mq($from: '#{$gel-grid-breakpoint-namespace}#{$breakpoint}') {
+      @include floats($breakpoint-name);
     }
+  }
 }

--- a/demo/src/bower.json
+++ b/demo/src/bower.json
@@ -2,25 +2,12 @@
   "name": "gel-grid-demo",
   "description": "A demo of the GEL Grid",
   "main": "index.html",
-  "authors": [
-    "Shaun Bent <shaun.bent@bbc.co.uk> (http://www.bbc.co.uk)"
-  ],
+  "authors": ["Shaun Bent <shaun.bent@bbc.co.uk> (http://www.bbc.co.uk)"],
   "license": "MIT",
-  "keywords": [
-    "GEL",
-    "Grid",
-    "Responsive",
-    "Flexbox"
-  ],
+  "keywords": ["GEL", "Grid", "Responsive", "Flexbox"],
   "homepage": "https://github.com/bbc/gel-grid",
   "private": true,
-  "ignore": [
-    "**/.*",
-    "node_modules",
-    "bower_components",
-    "test",
-    "tests"
-  ],
+  "ignore": ["**/.*", "node_modules", "bower_components", "test", "tests"],
   "dependencies": {
     "bbc-grandstand": "git@github.com:bbc/bbc-grandstand.git#^3.0.0"
   }

--- a/demo/src/index.html
+++ b/demo/src/index.html
@@ -1,547 +1,731 @@
-<!DOCTYPE html>
+<!doctype html>
 <html class="no-js b-pw-1280" dir="ltr">
-<head>
+  <head>
     <meta charset="utf-8" />
     <title>GEL Grid Demo | BBC GEL</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <script>var GEL = { mustard: false };</script>
     <script>
-        GEL.mustard = (function () {
-            return (
-                'addEventListener' in window &&
-                'querySelector' in window.document &&
-                'localStorage' in window
-            );
-        })();
+      var GEL = { mustard: false };
+    </script>
+    <script>
+      GEL.mustard = (function () {
+        return (
+          'addEventListener' in window &&
+          'querySelector' in window.document &&
+          'localStorage' in window
+        );
+      })();
     </script>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.min.js"></script>
     <script>
-        if (GEL.mustard) {
-            document.write('<link rel="stylesheet" id="stylesheet" href="assets/css/gel-demo-enhanced.css" />');
-        } else {
-            document.write('<link rel="stylesheet" id="stylesheet" href="assets/css/gel-demo-base.css" />');
-        }
+      if (GEL.mustard) {
+        document.write(
+          '<link rel="stylesheet" id="stylesheet" href="assets/css/gel-demo-enhanced.css" />',
+        );
+      } else {
+        document.write(
+          '<link rel="stylesheet" id="stylesheet" href="assets/css/gel-demo-base.css" />',
+        );
+      }
     </script>
     <noscript>
-        <link rel="stylesheet" href="assets/css/gel-demo-base.css" />
+      <link rel="stylesheet" href="assets/css/gel-demo-base.css" />
     </noscript>
-</head>
-<body>
-<!-- GEL Demos Header -->
-<div class="gel-demo">
-	<header role="banner" class="gel-c-demo-header">
-	    <div class="gel-c-demo-header__banner">
-            <div class="gel-wrap gs-u-clearfix">
-				<div class="gel-c-demo-header__brand">
-                    <a class="gel-c-demo-header__brand-logo" href="https://www.bbc.co.uk/gel">
-                        <svg aria-label="BBC GEL Logo" width="164" height="39">
-                            <title>BBC GEL Logo</title>
-                            <image xlink:href="assets/images/bbc-gel-logo.svg" src="assets/images/bbc-gel-logo.png" width="100%" height="100%"></image>
-                        </svg>
-					</a>
-                    <i class="gel-c-demo-header__brand-beta gel-minion-bold">Beta</i>
-                </div>
-
-				<a class="gel-c-demo-header__banner-button gel-o-button gel-long-primer-bold" href="https://www.bbc.co.uk/gel/guidelines/typography">
-					Go to BBC GEL
-				</a>
+  </head>
+  <body>
+    <!-- GEL Demos Header -->
+    <div class="gel-demo">
+      <header role="banner" class="gel-c-demo-header">
+        <div class="gel-c-demo-header__banner">
+          <div class="gel-wrap gs-u-clearfix">
+            <div class="gel-c-demo-header__brand">
+              <a class="gel-c-demo-header__brand-logo" href="https://www.bbc.co.uk/gel">
+                <svg aria-label="BBC GEL Logo" width="164" height="39">
+                  <title>BBC GEL Logo</title>
+                  <image
+                    xlink:href="assets/images/bbc-gel-logo.svg"
+                    src="assets/images/bbc-gel-logo.png"
+                    width="100%"
+                    height="100%"
+                  ></image>
+                </svg>
+              </a>
+              <i class="gel-c-demo-header__brand-beta gel-minion-bold">Beta</i>
             </div>
+
+            <a
+              class="gel-c-demo-header__banner-button gel-o-button gel-long-primer-bold"
+              href="https://www.bbc.co.uk/gel/guidelines/typography"
+            >
+              Go to BBC GEL
+            </a>
+          </div>
         </div>
         <div class="gel-c-demo-header__intro">
-            <div class="gel-wrap">
-                <div class="gel-layout">
-                    <div class="gel-layout__item gel-3/4@l">
-                        <h1 class="gs-u-mb gel-canon-bold">Grid</h1>
-                        <p>This is a working demo of the <a href="https://www.bbc.co.uk/gel/guidelines/grid">GEL Grid Guidelines</a>. The demo shows how our flexible, percentage-based grid works and how you can use it to create a BBC website.</p>
-                    </div>
-                </div>
+          <div class="gel-wrap">
+            <div class="gel-layout">
+              <div class="gel-layout__item gel-3/4@l">
+                <h1 class="gs-u-mb gel-canon-bold">Grid</h1>
+                <p>
+                  This is a working demo of the
+                  <a href="https://www.bbc.co.uk/gel/guidelines/grid">GEL Grid Guidelines</a>. The
+                  demo shows how our flexible, percentage-based grid works and how you can use it to
+                  create a BBC website.
+                </p>
+              </div>
             </div>
+          </div>
         </div>
-	</header>
-    <main role="main" class="gs-u-pb++">
+      </header>
+      <main role="main" class="gs-u-pb++">
         <div class="gel-wrap">
-            <div class="gel-layout gel-layout--center">
-                <div class="gel-layout__item gel-10/12@xxl">
-                    <div class="gel-c-demo-controls gel-grid-controls">
-                        <p class="gel-double-pica gs-u-mb">Your device is currently using:</p>
-                        <p class="gel-c-grid-controls__group-name gel-great-primer gs-u-mb-"></p>
-                        <p class="gel-c-grid-controls__margin-gutter-size gel-brevier"></p>
-                        <div class="gel-c-demo-controls__options gel-brevier-bold">
-                            <button class="gel-c-demo-controls__option gel-c-grid-controls__option-toggle" id="rtl-toggle">Toggle RTL On</button>
-                            <button class="gel-c-demo-controls__option gel-c-grid-controls__option-toggle" id="overlay-toggle">Toggle Grid Overlay On</button>
-                        </div>
-                    </div>
+          <div class="gel-layout gel-layout--center">
+            <div class="gel-layout__item gel-10/12@xxl">
+              <div class="gel-c-demo-controls gel-grid-controls">
+                <p class="gel-double-pica gs-u-mb">Your device is currently using:</p>
+                <p class="gel-c-grid-controls__group-name gel-great-primer gs-u-mb-"></p>
+                <p class="gel-c-grid-controls__margin-gutter-size gel-brevier"></p>
+                <div class="gel-c-demo-controls__options gel-brevier-bold">
+                  <button
+                    class="gel-c-demo-controls__option gel-c-grid-controls__option-toggle"
+                    id="rtl-toggle"
+                  >
+                    Toggle RTL On
+                  </button>
+                  <button
+                    class="gel-c-demo-controls__option gel-c-grid-controls__option-toggle"
+                    id="overlay-toggle"
+                  >
+                    Toggle Grid Overlay On
+                  </button>
                 </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="gel-c-grid-demo-section" id="sizes">
+            <h2 class="gel-double-pica-bold">Sizes</h2>
+
+            <div class="gel-layout gs-u-mt+">
+              <div class="gel-layout__item">
+                <div class="gel-c-grid-demo-item">100%</div>
+              </div>
             </div>
 
-            <div class="gel-c-grid-demo-section" id="sizes">
-                <h2 class="gel-double-pica-bold">Sizes</h2>
-
-                <div class="gel-layout gs-u-mt+">
-                    <div class="gel-layout__item">
-                        <div class="gel-c-grid-demo-item">100%</div>
-                    </div>
-                </div>
-
-                <div class="gel-layout gs-u-mt+">
-                    <div class="gel-layout__item gel-1/2">
-                        <div class="gel-c-grid-demo-item">50%</div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/2">
-                        <div class="gel-c-grid-demo-item">50%</div>
-                    </div>
-                </div>
-
-                <div class="gel-layout gs-u-mt+">
-                    <div class="gel-layout__item gel-1/3">
-                        <div class="gel-c-grid-demo-item">33.333%</div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/3">
-                        <div class="gel-c-grid-demo-item">33.333%</div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/3">
-                        <div class="gel-c-grid-demo-item">33.333%</div>
-                    </div>
-                </div>
-
-                <div class="gel-layout gs-u-mt+">
-                    <div class="gel-layout__item gel-1/4">
-                        <div class="gel-c-grid-demo-item">25%</div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/4">
-                        <div class="gel-c-grid-demo-item">25%</div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/4">
-                        <div class="gel-c-grid-demo-item">25%</div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/4">
-                        <div class="gel-c-grid-demo-item">25%</div>
-                    </div>
-                </div>
-
-                <div class="gel-layout gs-u-mt+">
-                    <div class="gel-layout__item gel-1/5">
-                        <div class="gel-c-grid-demo-item">20%</div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/5">
-                        <div class="gel-c-grid-demo-item">20%</div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/5">
-                        <div class="gel-c-grid-demo-item">20%</div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/5">
-                        <div class="gel-c-grid-demo-item">20%</div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/5">
-                        <div class="gel-c-grid-demo-item">20%</div>
-                    </div>
-                </div>
-
-                <div class="gel-layout gs-u-mt+">
-                    <div class="gel-layout__item gel-1/8">
-                        <div class="gel-c-grid-demo-item">12.5%</div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/8">
-                        <div class="gel-c-grid-demo-item">12.5%</div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/8">
-                        <div class="gel-c-grid-demo-item">12.5%</div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/8">
-                        <div class="gel-c-grid-demo-item">12.5%</div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/8">
-                        <div class="gel-c-grid-demo-item">12.5%</div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/8">
-                        <div class="gel-c-grid-demo-item">12.5%</div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/8">
-                        <div class="gel-c-grid-demo-item">12.5%</div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/8">
-                        <div class="gel-c-grid-demo-item">12.5%</div>
-                    </div>
-                </div>
+            <div class="gel-layout gs-u-mt+">
+              <div class="gel-layout__item gel-1/2">
+                <div class="gel-c-grid-demo-item">50%</div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/2">
+                <div class="gel-c-grid-demo-item">50%</div>
+              </div>
             </div>
 
-            <div class="gel-c-grid-demo-section" id="example">
-                <h2 class="gel-double-pica-bold">Example grid combinations</h2>
-
-                <div class="gel-layout gs-u-mt+">
-                    <div class="gel-layout__item">
-                        <p class="gel-pica gs-u-mb">Quarter / Three Quarters</p>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/4@xs">
-                        <div class="gel-c-grid-demo-item">25%</div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-3/4@xs">
-                        <div class="gel-c-grid-demo-item">75%</div>
-                    </div>
-                </div>
-                <p class="gel-c-grid-demo__summary gel-brevier">Applied at extra small (240px) devices and above.</p>
-
-                <div class="gel-layout gs-u-mt+">
-                    <div class="gel-layout__item">
-                        <p class="gel-pica gs-u-mb">Half / Quarter / Two Eighths</p>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/2@s">
-                        <div class="gel-c-grid-demo-item">50%</div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/4@s">
-                        <div class="gel-c-grid-demo-item">25%</div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/8@s">
-                        <div class="gel-c-grid-demo-item">12.5%</div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/8@s">
-                        <div class="gel-c-grid-demo-item">12.5%</div>
-                    </div>
-                </div>
-                <p class="gel-c-grid-demo__summary gel-brevier">Applied at small (400px) devices and above.</p>
-
-                <div class="gel-layout gs-u-mt+">
-                    <div class="gel-layout__item">
-                        <p class="gel-pica gs-u-mb">Two Thirds / Third</p>
-                    </div><!--
-                 --><div class="gel-layout__item gel-2/3@m">
-                        <div class="gel-c-grid-demo-item">66.666%</div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/3@m">
-                        <div class="gel-c-grid-demo-item">33.333%</div>
-                    </div>
-                </div>
-                <p class="gel-c-grid-demo__summary gel-brevier">Applied at medium (600px) devices and above.</p>
-
-                <div class="gel-layout gs-u-mt+">
-                    <div class="gel-layout__item">
-                        <p class="gel-pica gs-u-mb">Half / Three Sixths</p>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/2@l">
-                        <div class="gel-c-grid-demo-item">50%</div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/2@l">
-                        <div class="gel-layout gs-u-mt+ gs-u-mt0@l">
-                           <div class="gel-layout__item gel-1/3@s">
-                               <div class="gel-c-grid-demo-item">33.333%</div>
-                           </div><!--
-                        --><div class="gel-layout__item gel-1/3@s">
-                               <div class="gel-c-grid-demo-item">33.333%</div>
-                           </div><!--
-                        --><div class="gel-layout__item gel-1/3@s">
-                               <div class="gel-c-grid-demo-item">33.333%</div>
-                           </div>
-                        </div>
-                    </div>
-                </div>
-                <p class="gel-c-grid-demo__summary gel-brevier">Applied at large (900px) devices and above.</p>
+            <div class="gel-layout gs-u-mt+">
+              <div class="gel-layout__item gel-1/3">
+                <div class="gel-c-grid-demo-item">33.333%</div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/3">
+                <div class="gel-c-grid-demo-item">33.333%</div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/3">
+                <div class="gel-c-grid-demo-item">33.333%</div>
+              </div>
             </div>
 
-            <div class="gel-c-grid-demo-section" id="nested-grids">
-                <h2 class="gel-double-pica-bold">Nested Grids</h2>
+            <div class="gel-layout gs-u-mt+">
+              <div class="gel-layout__item gel-1/4">
+                <div class="gel-c-grid-demo-item">25%</div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/4">
+                <div class="gel-c-grid-demo-item">25%</div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/4">
+                <div class="gel-c-grid-demo-item">25%</div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/4">
+                <div class="gel-c-grid-demo-item">25%</div>
+              </div>
+            </div>
 
-                <div class="gel-layout gel-layout--equal gs-u-mt+">
-                    <div class="gel-layout__item gel-1/2@m">
+            <div class="gel-layout gs-u-mt+">
+              <div class="gel-layout__item gel-1/5">
+                <div class="gel-c-grid-demo-item">20%</div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/5">
+                <div class="gel-c-grid-demo-item">20%</div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/5">
+                <div class="gel-c-grid-demo-item">20%</div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/5">
+                <div class="gel-c-grid-demo-item">20%</div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/5">
+                <div class="gel-c-grid-demo-item">20%</div>
+              </div>
+            </div>
+
+            <div class="gel-layout gs-u-mt+">
+              <div class="gel-layout__item gel-1/8">
+                <div class="gel-c-grid-demo-item">12.5%</div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/8">
+                <div class="gel-c-grid-demo-item">12.5%</div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/8">
+                <div class="gel-c-grid-demo-item">12.5%</div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/8">
+                <div class="gel-c-grid-demo-item">12.5%</div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/8">
+                <div class="gel-c-grid-demo-item">12.5%</div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/8">
+                <div class="gel-c-grid-demo-item">12.5%</div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/8">
+                <div class="gel-c-grid-demo-item">12.5%</div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/8">
+                <div class="gel-c-grid-demo-item">12.5%</div>
+              </div>
+            </div>
+          </div>
+
+          <div class="gel-c-grid-demo-section" id="example">
+            <h2 class="gel-double-pica-bold">Example grid combinations</h2>
+
+            <div class="gel-layout gs-u-mt+">
+              <div class="gel-layout__item">
+                <p class="gel-pica gs-u-mb">Quarter / Three Quarters</p>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/4@xs">
+                <div class="gel-c-grid-demo-item">25%</div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-3/4@xs">
+                <div class="gel-c-grid-demo-item">75%</div>
+              </div>
+            </div>
+            <p class="gel-c-grid-demo__summary gel-brevier">
+              Applied at extra small (240px) devices and above.
+            </p>
+
+            <div class="gel-layout gs-u-mt+">
+              <div class="gel-layout__item">
+                <p class="gel-pica gs-u-mb">Half / Quarter / Two Eighths</p>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/2@s">
+                <div class="gel-c-grid-demo-item">50%</div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/4@s">
+                <div class="gel-c-grid-demo-item">25%</div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/8@s">
+                <div class="gel-c-grid-demo-item">12.5%</div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/8@s">
+                <div class="gel-c-grid-demo-item">12.5%</div>
+              </div>
+            </div>
+            <p class="gel-c-grid-demo__summary gel-brevier">
+              Applied at small (400px) devices and above.
+            </p>
+
+            <div class="gel-layout gs-u-mt+">
+              <div class="gel-layout__item">
+                <p class="gel-pica gs-u-mb">Two Thirds / Third</p>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-2/3@m">
+                <div class="gel-c-grid-demo-item">66.666%</div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/3@m">
+                <div class="gel-c-grid-demo-item">33.333%</div>
+              </div>
+            </div>
+            <p class="gel-c-grid-demo__summary gel-brevier">
+              Applied at medium (600px) devices and above.
+            </p>
+
+            <div class="gel-layout gs-u-mt+">
+              <div class="gel-layout__item">
+                <p class="gel-pica gs-u-mb">Half / Three Sixths</p>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/2@l">
+                <div class="gel-c-grid-demo-item">50%</div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/2@l">
+                <div class="gel-layout gs-u-mt+ gs-u-mt0@l">
+                  <div class="gel-layout__item gel-1/3@s">
+                    <div class="gel-c-grid-demo-item">33.333%</div>
+                  </div>
+                  <!--
+                        -->
+                  <div class="gel-layout__item gel-1/3@s">
+                    <div class="gel-c-grid-demo-item">33.333%</div>
+                  </div>
+                  <!--
+                        -->
+                  <div class="gel-layout__item gel-1/3@s">
+                    <div class="gel-c-grid-demo-item">33.333%</div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <p class="gel-c-grid-demo__summary gel-brevier">
+              Applied at large (900px) devices and above.
+            </p>
+          </div>
+
+          <div class="gel-c-grid-demo-section" id="nested-grids">
+            <h2 class="gel-double-pica-bold">Nested Grids</h2>
+
+            <div class="gel-layout gel-layout--equal gs-u-mt+">
+              <div class="gel-layout__item gel-1/2@m">
+                <div class="gel-c-grid-demo-item gel-pica">50%</div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/2@m">
+                <div class="gel-layout">
+                  <div class="gel-layout__item gel-1/3@s">
+                    <div class="gel-c-grid-demo-item gel-pica">33.333%</div>
+                  </div>
+                  <!--
+                         -->
+                  <div class="gel-layout__item gel-2/3@s">
+                    <div class="gel-layout">
+                      <div class="gel-layout__item gel-1/2">
                         <div class="gel-c-grid-demo-item gel-pica">50%</div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/2@m">
-                        <div class="gel-layout">
-                            <div class="gel-layout__item gel-1/3@s">
-                                <div class="gel-c-grid-demo-item gel-pica">33.333%</div>
-                            </div><!--
-                         --><div class="gel-layout__item gel-2/3@s">
-                                <div class="gel-layout">
-                                    <div class="gel-layout__item gel-1/2">
-                                        <div class="gel-c-grid-demo-item gel-pica">50%</div>
-                                    </div><!--
-                                 --><div class="gel-layout__item gel-1/2">
-                                        <div class="gel-c-grid-demo-item gel-pica">50%</div>
-                                    </div><!--
-                                 --><div class="gel-layout__item gel-1/3">
-                                        <div class="gel-c-grid-demo-item gel-pica">33.333%</div>
-                                    </div><!--
-                                 --><div class="gel-layout__item gel-1/3">
-                                        <div class="gel-c-grid-demo-item gel-pica">33.333%</div>
-                                    </div><!--
-                                 --><div class="gel-layout__item gel-1/3">
-                                        <div class="gel-c-grid-demo-item gel-pica">33.333%</div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+                      </div>
+                      <!--
+                                 -->
+                      <div class="gel-layout__item gel-1/2">
+                        <div class="gel-c-grid-demo-item gel-pica">50%</div>
+                      </div>
+                      <!--
+                                 -->
+                      <div class="gel-layout__item gel-1/3">
+                        <div class="gel-c-grid-demo-item gel-pica">33.333%</div>
+                      </div>
+                      <!--
+                                 -->
+                      <div class="gel-layout__item gel-1/3">
+                        <div class="gel-c-grid-demo-item gel-pica">33.333%</div>
+                      </div>
+                      <!--
+                                 -->
+                      <div class="gel-layout__item gel-1/3">
+                        <div class="gel-c-grid-demo-item gel-pica">33.333%</div>
+                      </div>
                     </div>
+                  </div>
                 </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="gel-c-grid-demo-section" id="equal-height">
+            <h2 class="gel-double-pica-bold">Equal Height</h2>
+
+            <div class="gel-layout gel-layout--equal gs-u-mt+">
+              <div class="gel-layout__item gel-1/2">
+                <div
+                  class="gel-c-grid-demo-item gel-c-grid-demo-item--auto gel-c-grid-demo-item--fill"
+                ></div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/2">
+                <div
+                  class="gel-c-grid-demo-item gel-c-grid-demo-item--large gel-c-grid-demo-item--fill"
+                ></div>
+              </div>
+            </div>
+            <p class="gel-c-grid-demo__summary gel-brevier">
+              Applied with the class: <code>gel-layout--equal</code>. This option only works for
+              browsers which support <code>flexbox</code>
+            </p>
+          </div>
+
+          <div class="gel-c-grid-demo-section" id="horizontal-alignment">
+            <h2 class="gel-double-pica-bold">Horizontal Alignment</h2>
+
+            <div class="gel-layout gs-u-mt+">
+              <div class="gel-layout__item gel-1/2">
+                <p class="gel-pica gs-u-mb-">Left</p>
+                <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
+              </div>
             </div>
 
-            <div class="gel-c-grid-demo-section" id="equal-height">
-                <h2 class="gel-double-pica-bold">Equal Height</h2>
-
-                <div class="gel-layout gel-layout--equal gs-u-mt+">
-                    <div class="gel-layout__item gel-1/2">
-                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--auto gel-c-grid-demo-item--fill"></div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/2">
-                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--large gel-c-grid-demo-item--fill"></div>
-                    </div>
-                </div>
-                <p class="gel-c-grid-demo__summary gel-brevier">Applied with the class: <code>gel-layout--equal</code>. This option only works for browsers which support <code>flexbox</code></p>
+            <div class="gel-layout gel-layout--center gs-u-mt+">
+              <div class="gel-layout__item gel-1/2">
+                <p class="gel-pica gs-u-mb-">Centre</p>
+                <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
+                <p class="gel-c-grid-demo__summary gel-brevier">
+                  Applied with the class: <code>gel-layout--center</code>
+                </p>
+              </div>
             </div>
 
-            <div class="gel-c-grid-demo-section" id="horizontal-alignment">
-                <h2 class="gel-double-pica-bold">Horizontal Alignment</h2>
-
-                <div class="gel-layout gs-u-mt+">
-                    <div class="gel-layout__item gel-1/2">
-                        <p class="gel-pica gs-u-mb-">Left</p>
-                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
-                    </div>
-                </div>
-
-                <div class="gel-layout gel-layout--center gs-u-mt+">
-                    <div class="gel-layout__item gel-1/2">
-                        <p class="gel-pica gs-u-mb-">Centre</p>
-                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
-                        <p class="gel-c-grid-demo__summary gel-brevier">Applied with the class: <code>gel-layout--center</code></p>
-                    </div>
-                </div>
-
-                <div class="gel-layout gel-layout--right gs-u-mt+">
-                    <div class="gel-layout__item gel-1/2">
-                        <p class="gel-pica gs-u-mb-">Right</p>
-                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
-                        <p class="gel-c-grid-demo__summary gel-brevier">Applied with the class: <code>gel-layout--right</code></p>
-                    </div>
-                </div>
+            <div class="gel-layout gel-layout--right gs-u-mt+">
+              <div class="gel-layout__item gel-1/2">
+                <p class="gel-pica gs-u-mb-">Right</p>
+                <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
+                <p class="gel-c-grid-demo__summary gel-brevier">
+                  Applied with the class: <code>gel-layout--right</code>
+                </p>
+              </div>
             </div>
+          </div>
 
-            <div class="gel-c-grid-demo-section" id="top-alignment">
-                <h2 class="gel-double-pica-bold">Top Alignment</h2>
+          <div class="gel-c-grid-demo-section" id="top-alignment">
+            <h2 class="gel-double-pica-bold">Top Alignment</h2>
 
-                <div class="gel-layout gs-u-mt+">
-                    <div class="gel-layout__item gel-1/3">
-                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/3">
-                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--large gel-c-grid-demo-item--fill"></div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/3">
-                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
-                    </div>
-                </div>
+            <div class="gel-layout gs-u-mt+">
+              <div class="gel-layout__item gel-1/3">
+                <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/3">
+                <div
+                  class="gel-c-grid-demo-item gel-c-grid-demo-item--large gel-c-grid-demo-item--fill"
+                ></div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/3">
+                <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
+              </div>
             </div>
+          </div>
 
-            <div class="gel-c-grid-demo-section" id="middle-alignment">
-                <h2 class="gel-double-pica-bold">Middle Alignment</h2>
+          <div class="gel-c-grid-demo-section" id="middle-alignment">
+            <h2 class="gel-double-pica-bold">Middle Alignment</h2>
 
-                <div class="gel-layout gel-layout--middle gs-u-mt+">
-                    <div class="gel-layout__item gel-1/3">
-                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/3">
-                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--large gel-c-grid-demo-item--fill"></div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/3">
-                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
-                    </div>
-                </div>
-                <p class="gel-c-grid-demo__summary gel-brevier">Applied with the class: <code>gel-layout--middle</code></p>
+            <div class="gel-layout gel-layout--middle gs-u-mt+">
+              <div class="gel-layout__item gel-1/3">
+                <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/3">
+                <div
+                  class="gel-c-grid-demo-item gel-c-grid-demo-item--large gel-c-grid-demo-item--fill"
+                ></div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/3">
+                <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
+              </div>
             </div>
+            <p class="gel-c-grid-demo__summary gel-brevier">
+              Applied with the class: <code>gel-layout--middle</code>
+            </p>
+          </div>
 
-            <div class="gel-c-grid-demo-section" id="bottom-alignment">
-                <h2 class="gel-double-pica-bold">Bottom Alignment</h2>
+          <div class="gel-c-grid-demo-section" id="bottom-alignment">
+            <h2 class="gel-double-pica-bold">Bottom Alignment</h2>
 
-                <div class="gel-layout gel-layout--bottom gs-u-mt+">
-                    <div class="gel-layout__item gel-1/3">
-                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/3">
-                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--large gel-c-grid-demo-item--fill"></div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/3">
-                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
-                    </div>
-                </div>
-                <p class="gel-c-grid-demo__summary gel-brevier">Applied with the class: <code>gel-layout--bottom</code></p>
+            <div class="gel-layout gel-layout--bottom gs-u-mt+">
+              <div class="gel-layout__item gel-1/3">
+                <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/3">
+                <div
+                  class="gel-c-grid-demo-item gel-c-grid-demo-item--large gel-c-grid-demo-item--fill"
+                ></div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/3">
+                <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
+              </div>
             </div>
+            <p class="gel-c-grid-demo__summary gel-brevier">
+              Applied with the class: <code>gel-layout--bottom</code>
+            </p>
+          </div>
 
-            <div class="gel-c-grid-demo-section" id="reversed">
-                <h2 class="gel-double-pica-bold">Reversed</h2>
+          <div class="gel-c-grid-demo-section" id="reversed">
+            <h2 class="gel-double-pica-bold">Reversed</h2>
 
-                <div class="gel-layout gel-layout--rev gs-u-mt+">
-                    <div class="gel-layout__item gel-1/4">
-                        <p class="gel-pica gs-u-mb-">1</p>
-                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/4">
-                        <p class="gel-pica gs-u-mb-">2</p>
-                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/4">
-                        <p class="gel-pica gs-u-mb-">3</p>
-                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/4">
-                        <p class="gel-pica gs-u-mb-">4</p>
-                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
-                    </div>
-                </div>
-                <p class="gel-c-grid-demo__summary gel-brevier">Applied with the class: <code>gel-layout--rev</code></p>
+            <div class="gel-layout gel-layout--rev gs-u-mt+">
+              <div class="gel-layout__item gel-1/4">
+                <p class="gel-pica gs-u-mb-">1</p>
+                <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/4">
+                <p class="gel-pica gs-u-mb-">2</p>
+                <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/4">
+                <p class="gel-pica gs-u-mb-">3</p>
+                <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/4">
+                <p class="gel-pica gs-u-mb-">4</p>
+                <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
+              </div>
             </div>
+            <p class="gel-c-grid-demo__summary gel-brevier">
+              Applied with the class: <code>gel-layout--rev</code>
+            </p>
+          </div>
 
-            <div class="gel-c-grid-demo-section" id="independent-alignment">
-                <h2 class="gel-double-pica-bold">Independent Alignment</h2>
+          <div class="gel-c-grid-demo-section" id="independent-alignment">
+            <h2 class="gel-double-pica-bold">Independent Alignment</h2>
 
-                <div class="gel-layout gs-u-mt+">
-                    <div class="gel-layout__item gel-layout__item--top gel-1/4">
-                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
-                        <p class="gel-brevier gs-u-mt-">Align Top</p>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/4">
-                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--large gel-c-grid-demo-item--fill"></div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-layout__item--center gel-1/4">
-                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
-                        <p class="gel-brevier gs-u-mt-">Align Center</p>
-                    </div><!--
-                 --><div class="gel-layout__item gel-layout__item--bottom gel-1/4">
-                        <p class="gel-brevier gs-u-mb-">Align Bottom</p>
-                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
-                    </div>
-                </div>
-                <p class="gel-c-grid-demo__summary gel-brevier">Applied with classes on individual layout items: <code>gel-layout__item--top</code>, <code>gel-layout__item--center</code>, <code>gel-layout__item--bottom</code></p>
+            <div class="gel-layout gs-u-mt+">
+              <div class="gel-layout__item gel-layout__item--top gel-1/4">
+                <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
+                <p class="gel-brevier gs-u-mt-">Align Top</p>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/4">
+                <div
+                  class="gel-c-grid-demo-item gel-c-grid-demo-item--large gel-c-grid-demo-item--fill"
+                ></div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-layout__item--center gel-1/4">
+                <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
+                <p class="gel-brevier gs-u-mt-">Align Center</p>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-layout__item--bottom gel-1/4">
+                <p class="gel-brevier gs-u-mb-">Align Bottom</p>
+                <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
+              </div>
             </div>
+            <p class="gel-c-grid-demo__summary gel-brevier">
+              Applied with classes on individual layout items: <code>gel-layout__item--top</code>,
+              <code>gel-layout__item--center</code>, <code>gel-layout__item--bottom</code>
+            </p>
+          </div>
 
-            <div class="gel-c-grid-demo-section" id="flush">
-                <h2 class="gel-double-pica-bold">Flush</h2>
+          <div class="gel-c-grid-demo-section" id="flush">
+            <h2 class="gel-double-pica-bold">Flush</h2>
 
-                <div class="gel-layout gel-layout--flush gs-u-mt+">
-                    <div class="gel-layout__item gel-1/4">
-                        <p class="gel-pica gs-u-mb-">1</p>
-                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/4">
-                        <p class="gel-pica gs-u-mb-">2</p>
-                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/4">
-                        <p class="gel-pica gs-u-mb-">3</p>
-                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/4">
-                        <p class="gel-pica gs-u-mb-">4</p>
-                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
-                    </div>
-                </div>
-                <p class="gel-c-grid-demo__summary gel-brevier">Applied with the class: <code>gel-layout--flush</code></p>
+            <div class="gel-layout gel-layout--flush gs-u-mt+">
+              <div class="gel-layout__item gel-1/4">
+                <p class="gel-pica gs-u-mb-">1</p>
+                <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/4">
+                <p class="gel-pica gs-u-mb-">2</p>
+                <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/4">
+                <p class="gel-pica gs-u-mb-">3</p>
+                <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/4">
+                <p class="gel-pica gs-u-mb-">4</p>
+                <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
+              </div>
             </div>
+            <p class="gel-c-grid-demo__summary gel-brevier">
+              Applied with the class: <code>gel-layout--flush</code>
+            </p>
+          </div>
 
-            <div class="gel-c-grid-demo-section" id="fit">
-                <h2 class="gel-double-pica-bold">Fit</h2>
+          <div class="gel-c-grid-demo-section" id="fit">
+            <h2 class="gel-double-pica-bold">Fit</h2>
 
-                <div class="gel-layout gel-layout--fit gs-u-mt+">
-                    <div class="gel-layout__item">
-                        <p class="gel-pica gs-u-mb-">1</p>
-                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
-                    </div><!--
-                 --><div class="gel-layout__item">
-                        <p class="gel-pica gs-u-mb-">2</p>
-                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
-                    </div><!--
-                 --><div class="gel-layout__item">
-                        <p class="gel-pica gs-u-mb-">3</p>
-                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
-                    </div><!--
-                 --><div class="gel-layout__item">
-                        <p class="gel-pica gs-u-mb-">4</p>
-                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
-                    </div>
-                </div>
-                <div class="gel-layout gel-layout--fit gs-u-mt+">
-                    <div class="gel-layout__item">
-                        <p class="gel-pica gs-u-mb-">1</p>
-                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
-                    </div><!--
-                 --><div class="gel-layout__item">
-                        <p class="gel-pica gs-u-mb-">2</p>
-                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
-                    </div>
-                </div>
-                <p class="gel-c-grid-demo__summary gel-brevier">Applied with the class: <code>gel-layout--fit</code>. This option only works for browsers which support <code>flexbox</code></p>
+            <div class="gel-layout gel-layout--fit gs-u-mt+">
+              <div class="gel-layout__item">
+                <p class="gel-pica gs-u-mb-">1</p>
+                <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item">
+                <p class="gel-pica gs-u-mb-">2</p>
+                <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item">
+                <p class="gel-pica gs-u-mb-">3</p>
+                <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item">
+                <p class="gel-pica gs-u-mb-">4</p>
+                <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
+              </div>
             </div>
+            <div class="gel-layout gel-layout--fit gs-u-mt+">
+              <div class="gel-layout__item">
+                <p class="gel-pica gs-u-mb-">1</p>
+                <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item">
+                <p class="gel-pica gs-u-mb-">2</p>
+                <div class="gel-c-grid-demo-item gel-c-grid-demo-item--fill"></div>
+              </div>
+            </div>
+            <p class="gel-c-grid-demo__summary gel-brevier">
+              Applied with the class: <code>gel-layout--fit</code>. This option only works for
+              browsers which support <code>flexbox</code>
+            </p>
+          </div>
         </div>
-    </main>
-</div>
+      </main>
+    </div>
 
-<script>
-function overlayTextToggle() {
-    var overlayToggle = document.getElementById('overlay-toggle');
-    overlayToggle.innerHTML === 'Toggle Grid Overlay On' ?
-        overlayToggle.innerHTML = 'Toggle Grid Overlay Off' : overlayToggle.innerHTML = 'Toggle Grid Overlay On';
-}
+    <script>
+      function overlayTextToggle() {
+        var overlayToggle = document.getElementById('overlay-toggle');
+        overlayToggle.innerHTML === 'Toggle Grid Overlay On'
+          ? (overlayToggle.innerHTML = 'Toggle Grid Overlay Off')
+          : (overlayToggle.innerHTML = 'Toggle Grid Overlay On');
+      }
 
-function gridOverlay() {
-    if (document.getElementsByClassName("gel-grid-overlay").length) {
-        document.getElementsByClassName("gel-grid-overlay")[0].remove()
-    }
-    var e = "<div class=\"gel-grid-overlay__grid\"><div class=\"gel-grid-overlay__margin\" style=\"left: 0;\"></div>";
-    for (i = 0; i < 12; i++) {
-        e += "<div class=\"gel-grid-overlay__column\"><div class=\"gel-grid-overlay__column-fill\"></div></div>"
-    }
-    e += "<div class=\"gel-grid-overlay__margin\" style=\"right: 0;\"></div>";
-    e += "</div>";
-    var t = document.createElement("div");
-    t.className = "gel-grid-overlay";
-    t.innerHTML = e;
-    var n = document.createElement("style");
-    n.innerHTML = ".gel-grid-overlay * {-moz-box-sizing: border-box; -webkit-box-sizing: border-box; box-sizing: border-box;);}.gel-grid-overlay {z-index: 2147483647; position: fixed; height: 100%; width: 100%; left: 0; top: 0;}.gel-grid-overlay__grid {position: relative; width: 100%; height: 100%; max-width: 1008px; margin: 0 auto; padding: 0 4px;}.gel-grid-overlay__column {display: inline-block; height: 100%; width: 8.33333%; padding: 0 4px;}.gel-grid-overlay__column-fill {background: rgba(255,0,0,0.1); height: 100%;}.gel-grid-overlay__margin {display: inline-block; height: 100%; width: 8px; position: absolute; top: 0; background: rgba(0,255,0,0.1);}@media screen and (min-width: 400px) {.gel-grid-overlay__grid {padding: 0 12px;}.gel-grid-overlay__margin {width: 16px;}@media screen and (min-width: 600px) {.gel-grid-overlay__grid {padding: 0 8px;}.gel-grid-overlay__column {padding: 0 8px;}}@media screen and (min-width: 1280px) {.gel-grid-overlay__grid {max-width: 1280px;}}";
-    document.getElementsByTagName("head")[0].appendChild(n);
-    document.getElementsByTagName("body")[0].appendChild(t);
-    t.addEventListener("click", function() {
-        document.getElementsByClassName("gel-grid-overlay")[0].remove();
-        overlayTextToggle();
-    });
-}
+      function gridOverlay() {
+        if (document.getElementsByClassName('gel-grid-overlay').length) {
+          document.getElementsByClassName('gel-grid-overlay')[0].remove();
+        }
+        var e =
+          '<div class="gel-grid-overlay__grid"><div class="gel-grid-overlay__margin" style="left: 0;"></div>';
+        for (i = 0; i < 12; i++) {
+          e +=
+            '<div class="gel-grid-overlay__column"><div class="gel-grid-overlay__column-fill"></div></div>';
+        }
+        e += '<div class="gel-grid-overlay__margin" style="right: 0;"></div>';
+        e += '</div>';
+        var t = document.createElement('div');
+        t.className = 'gel-grid-overlay';
+        t.innerHTML = e;
+        var n = document.createElement('style');
+        n.innerHTML =
+          '.gel-grid-overlay * {-moz-box-sizing: border-box; -webkit-box-sizing: border-box; box-sizing: border-box;);}.gel-grid-overlay {z-index: 2147483647; position: fixed; height: 100%; width: 100%; left: 0; top: 0;}.gel-grid-overlay__grid {position: relative; width: 100%; height: 100%; max-width: 1008px; margin: 0 auto; padding: 0 4px;}.gel-grid-overlay__column {display: inline-block; height: 100%; width: 8.33333%; padding: 0 4px;}.gel-grid-overlay__column-fill {background: rgba(255,0,0,0.1); height: 100%;}.gel-grid-overlay__margin {display: inline-block; height: 100%; width: 8px; position: absolute; top: 0; background: rgba(0,255,0,0.1);}@media screen and (min-width: 400px) {.gel-grid-overlay__grid {padding: 0 12px;}.gel-grid-overlay__margin {width: 16px;}@media screen and (min-width: 600px) {.gel-grid-overlay__grid {padding: 0 8px;}.gel-grid-overlay__column {padding: 0 8px;}}@media screen and (min-width: 1280px) {.gel-grid-overlay__grid {max-width: 1280px;}}';
+        document.getElementsByTagName('head')[0].appendChild(n);
+        document.getElementsByTagName('body')[0].appendChild(t);
+        t.addEventListener('click', function () {
+          document.getElementsByClassName('gel-grid-overlay')[0].remove();
+          overlayTextToggle();
+        });
+      }
 
-function toggleStyles() {
-    var html = document.querySelector('html');
-    var stylesheet = document.getElementById('stylesheet');
-    var rtlToggle = document.getElementById('rtl-toggle');
+      function toggleStyles() {
+        var html = document.querySelector('html');
+        var stylesheet = document.getElementById('stylesheet');
+        var rtlToggle = document.getElementById('rtl-toggle');
 
-    rtlToggle.innerHTML = (rtlToggle.innerHTML === 'Toggle RTL On') ?
-        'Toggle RTL Off' : 'Toggle RTL On';
+        rtlToggle.innerHTML =
+          rtlToggle.innerHTML === 'Toggle RTL On' ? 'Toggle RTL Off' : 'Toggle RTL On';
 
-    if (stylesheet.getAttribute('href').indexOf('-rtl') > -1) {
-        if (GEL.mustard) {
+        if (stylesheet.getAttribute('href').indexOf('-rtl') > -1) {
+          if (GEL.mustard) {
             stylesheet.setAttribute('href', 'assets/css/gel-demo-enhanced.css');
-        } else {
+          } else {
             stylesheet.setAttribute('href', 'assets/css/gel-demo-base.css');
-        }
+          }
 
-        html.setAttribute('dir', 'ltr');
-    } else {
-        if (GEL.mustard) {
-            stylesheet.setAttribute('href', 'assets/css/gel-demo-enhanced-rtl.css');
+          html.setAttribute('dir', 'ltr');
         } else {
+          if (GEL.mustard) {
+            stylesheet.setAttribute('href', 'assets/css/gel-demo-enhanced-rtl.css');
+          } else {
             stylesheet.setAttribute('href', 'assets/css/gel-demo-base-rtl.css');
+          }
+
+          html.setAttribute('dir', 'rtl');
         }
+      }
 
-        html.setAttribute('dir', 'rtl');
-    }
-}
+      (function () {
+        var overlayToggle = document.getElementById('overlay-toggle');
+        overlayToggle.addEventListener('click', function () {
+          gridOverlay();
+          overlayTextToggle();
+        });
 
-(function() {
-    var overlayToggle = document.getElementById('overlay-toggle');
-    overlayToggle.addEventListener('click', function() {
-        gridOverlay();
-        overlayTextToggle();
-    });
-
-    var rtlToggle = document.getElementById('rtl-toggle');
-    rtlToggle.addEventListener('click', function() {
-        toggleStyles();
-    });
-}());
-</script>
-</body>
+        var rtlToggle = document.getElementById('rtl-toggle');
+        rtlToggle.addEventListener('click', function () {
+          toggleStyles();
+        });
+      })();
+    </script>
+  </body>
 </html>

--- a/demo/src/promo.html
+++ b/demo/src/promo.html
@@ -1,634 +1,857 @@
-<!DOCTYPE html>
+<!doctype html>
 <html class="no-js b-pw-1280" dir="ltr">
-<head>
+  <head>
     <meta charset="utf-8" />
     <title>GEL Grid Demo | BBC GEL</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <script>var GEL = { mustard: false };</script>
     <script>
-        GEL.mustard = (function () {
-            return (
-                'addEventListener' in window &&
-                'querySelector' in window.document &&
-                'localStorage' in window
-            );
-        })();
+      var GEL = { mustard: false };
+    </script>
+    <script>
+      GEL.mustard = (function () {
+        return (
+          'addEventListener' in window &&
+          'querySelector' in window.document &&
+          'localStorage' in window
+        );
+      })();
     </script>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.min.js"></script>
     <script>
-        if (GEL.mustard) {
-            document.write('<link rel="stylesheet" id="stylesheet" href="assets/css/gel-demo-enhanced.css" />');
-        } else {
-            document.write('<link rel="stylesheet" id="stylesheet" href="assets/css/gel-demo-base.css" />');
-        }
+      if (GEL.mustard) {
+        document.write(
+          '<link rel="stylesheet" id="stylesheet" href="assets/css/gel-demo-enhanced.css" />',
+        );
+      } else {
+        document.write(
+          '<link rel="stylesheet" id="stylesheet" href="assets/css/gel-demo-base.css" />',
+        );
+      }
     </script>
     <noscript>
-        <link rel="stylesheet" href="assets/css/gel-demo-base.css" />
+      <link rel="stylesheet" href="assets/css/gel-demo-base.css" />
     </noscript>
-</head>
-<body>
-<!-- GEL Demos Header -->
-<div class="gel-demo">
-	<header role="banner" class="gel-c-demo-header">
-	    <div class="gel-c-demo-header__banner">
-            <div class="gel-wrap gs-u-clearfix">
-				<div class="gel-c-demo-header__brand">
-                    <a class="gel-c-demo-header__brand-logo" href="https://www.bbc.co.uk/gel">
-                        <svg aria-label="BBC GEL Logo" width="164" height="39">
-                            <title>BBC GEL Logo</title>
-                            <image xlink:href="assets/images/bbc-gel-logo.svg" src="assets/images/bbc-gel-logo.png" width="100%" height="100%"></image>
-                        </svg>
-					</a>
-                    <i class="gel-c-demo-header__brand-beta gel-minion-bold">Beta</i>
-                </div>
-
-				<a class="gel-c-demo-header__banner-button gel-o-button gel-long-primer-bold" href="https://www.bbc.co.uk/gel/guidelines/typography">
-					Go to BBC GEL
-				</a>
+  </head>
+  <body>
+    <!-- GEL Demos Header -->
+    <div class="gel-demo">
+      <header role="banner" class="gel-c-demo-header">
+        <div class="gel-c-demo-header__banner">
+          <div class="gel-wrap gs-u-clearfix">
+            <div class="gel-c-demo-header__brand">
+              <a class="gel-c-demo-header__brand-logo" href="https://www.bbc.co.uk/gel">
+                <svg aria-label="BBC GEL Logo" width="164" height="39">
+                  <title>BBC GEL Logo</title>
+                  <image
+                    xlink:href="assets/images/bbc-gel-logo.svg"
+                    src="assets/images/bbc-gel-logo.png"
+                    width="100%"
+                    height="100%"
+                  ></image>
+                </svg>
+              </a>
+              <i class="gel-c-demo-header__brand-beta gel-minion-bold">Beta</i>
             </div>
+
+            <a
+              class="gel-c-demo-header__banner-button gel-o-button gel-long-primer-bold"
+              href="https://www.bbc.co.uk/gel/guidelines/typography"
+            >
+              Go to BBC GEL
+            </a>
+          </div>
         </div>
         <div class="gel-c-demo-header__intro">
-            <div class="gel-wrap">
-                <div class="gel-layout">
-                    <div class="gel-layout__item gel-3/4@l">
-                        <h1 class="gs-u-mb gel-canon-bold">Grid</h1>
-                        <p>This is a working demo of the <a href="https://www.bbc.co.uk/gel/guidelines/grid">GEL Grid Guidelines</a>. The demo shows how our flexible, percentage-based grid works and how you can use it to create a BBC website.</p>
-                    </div>
-                </div>
+          <div class="gel-wrap">
+            <div class="gel-layout">
+              <div class="gel-layout__item gel-3/4@l">
+                <h1 class="gs-u-mb gel-canon-bold">Grid</h1>
+                <p>
+                  This is a working demo of the
+                  <a href="https://www.bbc.co.uk/gel/guidelines/grid">GEL Grid Guidelines</a>. The
+                  demo shows how our flexible, percentage-based grid works and how you can use it to
+                  create a BBC website.
+                </p>
+              </div>
             </div>
+          </div>
         </div>
-	</header>
-    <main role="main" class="gs-u-pb++">
+      </header>
+      <main role="main" class="gs-u-pb++">
         <div class="gel-wrap">
-            <div class="gel-layout gel-layout--center">
-                <div class="gel-layout__item gel-10/12@xxl">
-                    <div class="gel-c-demo-controls gel-grid-controls">
-                        <p class="gel-double-pica gs-u-mb">Your device is currently using:</p>
-                        <p class="gel-c-grid-controls__group-name gel-great-primer gs-u-mb-"></p>
-                        <p class="gel-c-grid-controls__margin-gutter-size gel-brevier"></p>
-                        <div class="gel-c-demo-controls__options gel-brevier-bold">
-                            <button class="gel-c-demo-controls__option gel-c-grid-controls__option-toggle" id="rtl-toggle">Toggle RTL On</button>
-                            <button class="gel-c-demo-controls__option gel-c-grid-controls__option-toggle" id="overlay-toggle">Toggle Grid Overlay On</button>
-                        </div>
-                    </div>
+          <div class="gel-layout gel-layout--center">
+            <div class="gel-layout__item gel-10/12@xxl">
+              <div class="gel-c-demo-controls gel-grid-controls">
+                <p class="gel-double-pica gs-u-mb">Your device is currently using:</p>
+                <p class="gel-c-grid-controls__group-name gel-great-primer gs-u-mb-"></p>
+                <p class="gel-c-grid-controls__margin-gutter-size gel-brevier"></p>
+                <div class="gel-c-demo-controls__options gel-brevier-bold">
+                  <button
+                    class="gel-c-demo-controls__option gel-c-grid-controls__option-toggle"
+                    id="rtl-toggle"
+                  >
+                    Toggle RTL On
+                  </button>
+                  <button
+                    class="gel-c-demo-controls__option gel-c-grid-controls__option-toggle"
+                    id="overlay-toggle"
+                  >
+                    Toggle Grid Overlay On
+                  </button>
                 </div>
+              </div>
             </div>
+          </div>
 
-            <div class="gel-c-grid-demo-section">
-                <h2 class="gel-double-pica-bold">Nested Grid Examples</h2>
-                <div class="gel-c-grid-demo-promo">
-                    <div class="gel-layout gel-layout--no-flex">
-                        <div class="gel-layout__item gel-3/4@l gel-3/5@xxl gs-u-fl@l">
-                            <div class="gel-c-grid-demo-promo__image">
-                                <div class="gs-o-responsive-image gs-o-responsive-image--16by9">
-                                    <img src="http://ichef.bbci.co.uk/news/976/cpsprodpb/71B2/production/_89960192_epa_tributes.jpg" alt="Promo Image Placeholder" />
-                                </div>
-                            </div>
-                        </div><!--
-                     --><div class="gel-layout__item gel-2/3@m gel-1/4@l gel-2/5@xxl">
-                            <div class="gel-c-grid-demo-promo__body gs-u-mt+@m gs-u-pt gs-u-pt0@m">
-                                <div>
-                                    <h2 class="gel-pica-bold">Orlando gunman 'had grudge in his heart'</h2>
-                                    <p class="gel-long-primer gs-u-mt gs-u-display-none gs-u-display-block@m">The father of the gunman who killed 50 people in an Orlando gay club says his son had a "grudge in his heart".</p>
-                                </div>
-                                <ul class="gs-o-list-inline gs-o-list-inline--divided gel-brevier gs-u-mt+">
-                                    <li class="qa-timestamp">
-                                        <span class="gs-o-bullet gs-o-bullet-">
-                                            <span class="gs-o-bullet__icon gel-icon">
-                                                <svg viewBox="0 0 32 32">
-                                                    <path d="M16 4c6.6 0 12 5.4 12 12s-5.4 12-12 12S4 22.6 4 16 9.4 4 16 4zm0-4C7.2 0 0 7.2 0 16s7.2 16 16 16 16-7.2 16-16S24.8 0 16 0z"></path>
-                                                    <circle id="pulse" cx="16" cy="16" r="8.5"></circle>
-                                                </svg>
-                                            </span><!--
+          <div class="gel-c-grid-demo-section">
+            <h2 class="gel-double-pica-bold">Nested Grid Examples</h2>
+            <div class="gel-c-grid-demo-promo">
+              <div class="gel-layout gel-layout--no-flex">
+                <div class="gel-layout__item gel-3/4@l gel-3/5@xxl gs-u-fl@l">
+                  <div class="gel-c-grid-demo-promo__image">
+                    <div class="gs-o-responsive-image gs-o-responsive-image--16by9">
+                      <img
+                        src="http://ichef.bbci.co.uk/news/976/cpsprodpb/71B2/production/_89960192_epa_tributes.jpg"
+                        alt="Promo Image Placeholder"
+                      />
+                    </div>
+                  </div>
+                </div>
+                <!--
+                     -->
+                <div class="gel-layout__item gel-2/3@m gel-1/4@l gel-2/5@xxl">
+                  <div class="gel-c-grid-demo-promo__body gs-u-mt+@m gs-u-pt gs-u-pt0@m">
+                    <div>
+                      <h2 class="gel-pica-bold">Orlando gunman 'had grudge in his heart'</h2>
+                      <p class="gel-long-primer gs-u-mt gs-u-display-none gs-u-display-block@m">
+                        The father of the gunman who killed 50 people in an Orlando gay club says
+                        his son had a "grudge in his heart".
+                      </p>
+                    </div>
+                    <ul class="gs-o-list-inline gs-o-list-inline--divided gel-brevier gs-u-mt+">
+                      <li class="qa-timestamp">
+                        <span class="gs-o-bullet gs-o-bullet-">
+                          <span class="gs-o-bullet__icon gel-icon">
+                            <svg viewBox="0 0 32 32">
+                              <path
+                                d="M16 4c6.6 0 12 5.4 12 12s-5.4 12-12 12S4 22.6 4 16 9.4 4 16 4zm0-4C7.2 0 0 7.2 0 16s7.2 16 16 16 16-7.2 16-16S24.8 0 16 0z"
+                              ></path>
+                              <circle id="pulse" cx="16" cy="16" r="8.5"></circle>
+                            </svg> </span
+                          ><!--
                                          --><span class="gs-o-bullet__text">1m</span>
-                                        </span>
-                                    </li><!--
-                                 --><li class="qa-section-tag">
-                                        <span class="gs-o-section-tag gel-brevier">
-                                            <span class="gs-u-vh">From the section </span>
-                                            <a href="/sport/tennis">US &amp; Canada</a>
-                                        </span>
-                                    </li>
-                                </ul>
-                            </div>
-                        </div><!--
-                     --><div class="gel-layout__item gel-1/3@m gel-1/4@l gel-1/5@xxl gs-u-fr@xxl">
-                            <div class="live_promo promo__item gs-u-mt+">
-                                <ol class="lx-c-key-points">
-                                    <li class="lx-c-key-points__item lead_key-points_headline">
-                                        <a class="lx-c-key-points__link gs-o-media" href="#">
-                                            <div class="gs-o-media__img">
-                                                <span class="gs-o-bullet gs-o-bullet-">
-                                                    <span class="gs-o-bullet__icon gel-icon">
-                                                        <svg viewBox="0 0 32 32">
-                                                            <path d="M16 4c6.6 0 12 5.4 12 12s-5.4 12-12 12S4 22.6 4 16 9.4 4 16 4zm0-4C7.2 0 0 7.2 0 16s7.2 16 16 16 16-7.2 16-16S24.8 0 16 0z"></path>
-                                                            <circle id="pulse" cx="16" cy="16" r="8.5"></circle>
-                                                        </svg>
-                                                    </span><!--
+                        </span>
+                      </li>
+                      <!--
+                                 -->
+                      <li class="qa-section-tag">
+                        <span class="gs-o-section-tag gel-brevier">
+                          <span class="gs-u-vh">From the section </span>
+                          <a href="/sport/tennis">US &amp; Canada</a>
+                        </span>
+                      </li>
+                    </ul>
+                  </div>
+                </div>
+                <!--
+                     -->
+                <div class="gel-layout__item gel-1/3@m gel-1/4@l gel-1/5@xxl gs-u-fr@xxl">
+                  <div class="live_promo promo__item gs-u-mt+">
+                    <ol class="lx-c-key-points">
+                      <li class="lx-c-key-points__item lead_key-points_headline">
+                        <a class="lx-c-key-points__link gs-o-media" href="#">
+                          <div class="gs-o-media__img">
+                            <span class="gs-o-bullet gs-o-bullet-">
+                              <span class="gs-o-bullet__icon gel-icon">
+                                <svg viewBox="0 0 32 32">
+                                  <path
+                                    d="M16 4c6.6 0 12 5.4 12 12s-5.4 12-12 12S4 22.6 4 16 9.4 4 16 4zm0-4C7.2 0 0 7.2 0 16s7.2 16 16 16 16-7.2 16-16S24.8 0 16 0z"
+                                  ></path>
+                                  <circle id="pulse" cx="16" cy="16" r="8.5"></circle>
+                                </svg> </span
+                              ><!--
                                                  --><span class="gs-o-bullet__text">Live</span>
-                                                </span>
-                                            </div>
-                                            <div class="gs-o-media__body">
-                                                <span class="lx-c-key-points__text gel-pica-bold">Orlando nightclub shooting</span>
-                                            </div>
-                                        </a>
-                                    </li>
-                                    <li class="lx-c-key-points__item">
-                                        <a class="lx-c-key-points__link gs-o-media" href="#">
-                                            <div class="gs-o-media__img">
-                                                <div class="icon icon--type icon--keypoints">
-
-                                                </div>
-                                            </div>
-                                            <div class="gs-o-media__body">
-                                                <span class="lx-c-key-points__text gel-brevier">
-                                                    <time timestamp="{insert-time-stamp}" class="lx-c-key-points__timestamp">12m</time> Forty-nine people killed in attack on gay nightclub
-                                                </span>
-                                            </div>
-                                        </a>
-                                    </li>
-                                    <li class="lx-c-key-points__item">
-                                        <a class="lx-c-key-points__link gs-o-media" href="#">
-                                            <div class="gs-o-media__img">
-                                                <div class="icon icon--type icon--keypoints">
-
-                                                </div>
-                                            </div>
-                                            <div class="gs-o-media__body">
-                                                <span class="lx-c-key-points__text gel-brevier">
-                                                    <time timestamp="{insert-time-stamp}" class="lx-c-key-points__timestamp">22m</time> Suspect took hostages and died in gunfight with Swat officers
-                                                </span>
-                                            </div>
-                                        </a>
-                                    </li>
-                                </ol>
-                            </div>
-                        </div><!--
-                     --><div class="gel-layout__item gel-1/5@xxl">
-                            <ul class="see-also promo__item gs-u-mt+ gel-layout">
-                                <li class="bullets see-also__item gel-layout__item gel-1/2 gel-1/3@m gel-1/1@xxl gs-u-mb">
-                                    <a class="title-link" href="#">
-                                        <span class="title-link__title-text gel-brevier-bold">Gunman's father's grief</span>
-                                    </a>
-                                </li><!--
-                             --><li class="bullets see-also__item gel-layout__item gel-1/2 gel-1/3@m gel-1/1@xxl gs-u-mb">
-                                    <a class="title-link" href="#">
-                                        <span class="title-link__title-text gel-brevier-bold">Killer's ex-wife speaks out</span>
-                                    </a>
-                                </li><!--
-                             --><li class="bullets see-also__item gel-layout__item gel-1/2 gel-1/3@m gel-1/1@xxl gs-u-mb">
-                                    <a class="title-link" href="#">
-                                        <span class="title-link__title-text gel-brevier-bold">Who was Omar Mateen?</span>
-                                    </a>
-                                </li><!--
-                             --><li class="bullets see-also__item gel-layout__item gel-1/2 gel-1/3@m gel-1/1@xxl gs-u-mb">
-                                    <a class="title-link" href="#">
-                                        <span class="title-link__title-text gel-brevier-bold">US gun companies see share price rise</span>
-                                    </a>
-                                </li><!--
-                             --><li class="bullets see-also__item gel-layout__item gel-1/2 gel-1/3@m gel-1/1@xxl gs-u-mb">
-                                    <a class="title-link" href="#">
-                                        <span class="title-link__title-text gel-brevier-bold">Orlando shooting: Full report</span>
-                                    </a>
-                                </li><!--
-                             --><li class="bullets see-also__item  gel-layout__item gel-1/2 gel-1/3@m gel-1/1@xxl gs-u-mb">
-                                    <a class="title-link" href="#">
-                                        <span class="title-link__title-text gel-brevier-bold">Eyewitness accounts in Orlando shooting</span>
-                                    </a>
-                                </li>
-                            </ul>
-                        </div>
-                    </div>
+                            </span>
+                          </div>
+                          <div class="gs-o-media__body">
+                            <span class="lx-c-key-points__text gel-pica-bold"
+                              >Orlando nightclub shooting</span
+                            >
+                          </div>
+                        </a>
+                      </li>
+                      <li class="lx-c-key-points__item">
+                        <a class="lx-c-key-points__link gs-o-media" href="#">
+                          <div class="gs-o-media__img">
+                            <div class="icon icon--type icon--keypoints"></div>
+                          </div>
+                          <div class="gs-o-media__body">
+                            <span class="lx-c-key-points__text gel-brevier">
+                              <time
+                                timestamp="{insert-time-stamp}"
+                                class="lx-c-key-points__timestamp"
+                                >12m</time
+                              >
+                              Forty-nine people killed in attack on gay nightclub
+                            </span>
+                          </div>
+                        </a>
+                      </li>
+                      <li class="lx-c-key-points__item">
+                        <a class="lx-c-key-points__link gs-o-media" href="#">
+                          <div class="gs-o-media__img">
+                            <div class="icon icon--type icon--keypoints"></div>
+                          </div>
+                          <div class="gs-o-media__body">
+                            <span class="lx-c-key-points__text gel-brevier">
+                              <time
+                                timestamp="{insert-time-stamp}"
+                                class="lx-c-key-points__timestamp"
+                                >22m</time
+                              >
+                              Suspect took hostages and died in gunfight with Swat officers
+                            </span>
+                          </div>
+                        </a>
+                      </li>
+                    </ol>
+                  </div>
                 </div>
+                <!--
+                     -->
+                <div class="gel-layout__item gel-1/5@xxl">
+                  <ul class="see-also promo__item gs-u-mt+ gel-layout">
+                    <li
+                      class="bullets see-also__item gel-layout__item gel-1/2 gel-1/3@m gel-1/1@xxl gs-u-mb"
+                    >
+                      <a class="title-link" href="#">
+                        <span class="title-link__title-text gel-brevier-bold"
+                          >Gunman's father's grief</span
+                        >
+                      </a>
+                    </li>
+                    <!--
+                             -->
+                    <li
+                      class="bullets see-also__item gel-layout__item gel-1/2 gel-1/3@m gel-1/1@xxl gs-u-mb"
+                    >
+                      <a class="title-link" href="#">
+                        <span class="title-link__title-text gel-brevier-bold"
+                          >Killer's ex-wife speaks out</span
+                        >
+                      </a>
+                    </li>
+                    <!--
+                             -->
+                    <li
+                      class="bullets see-also__item gel-layout__item gel-1/2 gel-1/3@m gel-1/1@xxl gs-u-mb"
+                    >
+                      <a class="title-link" href="#">
+                        <span class="title-link__title-text gel-brevier-bold"
+                          >Who was Omar Mateen?</span
+                        >
+                      </a>
+                    </li>
+                    <!--
+                             -->
+                    <li
+                      class="bullets see-also__item gel-layout__item gel-1/2 gel-1/3@m gel-1/1@xxl gs-u-mb"
+                    >
+                      <a class="title-link" href="#">
+                        <span class="title-link__title-text gel-brevier-bold"
+                          >US gun companies see share price rise</span
+                        >
+                      </a>
+                    </li>
+                    <!--
+                             -->
+                    <li
+                      class="bullets see-also__item gel-layout__item gel-1/2 gel-1/3@m gel-1/1@xxl gs-u-mb"
+                    >
+                      <a class="title-link" href="#">
+                        <span class="title-link__title-text gel-brevier-bold"
+                          >Orlando shooting: Full report</span
+                        >
+                      </a>
+                    </li>
+                    <!--
+                             -->
+                    <li
+                      class="bullets see-also__item gel-layout__item gel-1/2 gel-1/3@m gel-1/1@xxl gs-u-mb"
+                    >
+                      <a class="title-link" href="#">
+                        <span class="title-link__title-text gel-brevier-bold"
+                          >Eyewitness accounts in Orlando shooting</span
+                        >
+                      </a>
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="gel-c-grid-demo-section">
+            <h2 class="gel-double-pica-bold">Sizes</h2>
+
+            <div class="gel-layout gs-u-mt+">
+              <div class="gel-layout__item">
+                <p class="gel-pica gs-u-mb">100% (Whole)</p>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item">
+                <div class="gel-c-grid-demo-item"></div>
+              </div>
             </div>
 
-            <div class="gel-c-grid-demo-section">
-                <h2 class="gel-double-pica-bold">Sizes</h2>
-
-                <div class="gel-layout gs-u-mt+">
-                    <div class="gel-layout__item">
-                        <p class="gel-pica gs-u-mb">100% (Whole)</p>
-                    </div><!--
-                 --><div class="gel-layout__item">
-                        <div class="gel-c-grid-demo-item"></div>
-                    </div>
-                </div>
-
-                <div class="gel-layout gs-u-mt+">
-                    <div class="gel-layout__item">
-                        <p class="gel-pica gs-u-mb">50% (Halves)</p>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/2">
-                        <div class="gel-c-grid-demo-item"></div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/2">
-                        <div class="gel-c-grid-demo-item"></div>
-                    </div>
-                </div>
-
-                <div class="gel-layout gs-u-mt+">
-                    <div class="gel-layout__item">
-                        <p class="gel-pica gs-u-mb">33.333% (Thirds)</p>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/3">
-                        <div class="gel-c-grid-demo-item"></div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/3">
-                        <div class="gel-c-grid-demo-item"></div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/3">
-                        <div class="gel-c-grid-demo-item"></div>
-                    </div>
-                </div>
-
-                <div class="gel-layout gs-u-mt+">
-                    <div class="gel-layout__item">
-                        <p class="gel-pica gs-u-mb">25% (Quarters)</p>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/4">
-                        <div class="gel-c-grid-demo-item"></div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/4">
-                        <div class="gel-c-grid-demo-item"></div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/4">
-                        <div class="gel-c-grid-demo-item"></div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/4">
-                        <div class="gel-c-grid-demo-item"></div>
-                    </div>
-                </div>
-
-                <div class="gel-layout gs-u-mt+">
-                    <div class="gel-layout__item">
-                        <p class="gel-pica gs-u-mb">20% (Fifths)</p>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/5">
-                        <div class="gel-c-grid-demo-item"></div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/5">
-                        <div class="gel-c-grid-demo-item"></div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/5">
-                        <div class="gel-c-grid-demo-item"></div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/5">
-                        <div class="gel-c-grid-demo-item"></div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/5">
-                        <div class="gel-c-grid-demo-item"></div>
-                    </div>
-                </div>
-
-                <div class="gel-layout gs-u-mt+">
-                    <div class="gel-layout__item">
-                        <p class="gel-pica gs-u-mb">12.5% (Eighths)</p>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/8">
-                        <div class="gel-c-grid-demo-item"></div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/8">
-                        <div class="gel-c-grid-demo-item"></div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/8">
-                        <div class="gel-c-grid-demo-item"></div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/8">
-                        <div class="gel-c-grid-demo-item"></div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/8">
-                        <div class="gel-c-grid-demo-item"></div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/8">
-                        <div class="gel-c-grid-demo-item"></div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/8">
-                        <div class="gel-c-grid-demo-item"></div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/8">
-                        <div class="gel-c-grid-demo-item"></div>
-                    </div>
-                </div>
+            <div class="gel-layout gs-u-mt+">
+              <div class="gel-layout__item">
+                <p class="gel-pica gs-u-mb">50% (Halves)</p>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/2">
+                <div class="gel-c-grid-demo-item"></div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/2">
+                <div class="gel-c-grid-demo-item"></div>
+              </div>
             </div>
 
-            <div class="gel-c-grid-demo-section">
-                <h2 class="gel-double-pica-bold">Example grid combinations</h2>
-
-                <div class="gel-layout gs-u-mt+">
-                    <div class="gel-layout__item">
-                        <p class="gel-pica gs-u-mb">Quarter / Three Quarters</p>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/4@xs">
-                        <div class="gel-c-grid-demo-item"></div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-3/4@xs">
-                        <div class="gel-c-grid-demo-item"></div>
-                    </div>
-                </div>
-                <p class="gel-c-grid-demo__summary gel-brevier">Applied at extra small (240px) devices and above.</p>
-
-                <div class="gel-layout gs-u-mt+">
-                    <div class="gel-layout__item">
-                        <p class="gel-pica gs-u-mb">Half / Quarter / Two Eighths</p>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/2@s">
-                        <div class="gel-c-grid-demo-item"></div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/4@s">
-                        <div class="gel-c-grid-demo-item"></div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/8@s">
-                        <div class="gel-c-grid-demo-item"></div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/8@s">
-                        <div class="gel-c-grid-demo-item"></div>
-                    </div>
-                </div>
-                <p class="gel-c-grid-demo__summary gel-brevier">Applied at small (400px) devices and above.</p>
-
-                <div class="gel-layout gs-u-mt+">
-                    <div class="gel-layout__item">
-                        <p class="gel-pica gs-u-mb">Two Thirds / Third</p>
-                    </div><!--
-                 --><div class="gel-layout__item gel-2/3@m">
-                        <div class="gel-c-grid-demo-item"></div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/3@m">
-                        <div class="gel-c-grid-demo-item"></div>
-                    </div>
-                </div>
-                <p class="gel-c-grid-demo__summary gel-brevier">Applied at medium (600px) devices and above.</p>
-
-                <div class="gel-layout gs-u-mt+">
-                    <div class="gel-layout__item">
-                        <p class="gel-pica gs-u-mb">Half / Three Sixths</p>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/2@l">
-                        <div class="gel-c-grid-demo-item"></div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/2@l">
-                        <div class="gel-layout gs-u-mt+ gs-u-mt0@l">
-                           <div class="gel-layout__item gel-1/3@s">
-                               <div class="gel-c-grid-demo-item"></div>
-                           </div><!--
-                        --><div class="gel-layout__item gel-1/3@s">
-                               <div class="gel-c-grid-demo-item"></div>
-                           </div><!--
-                        --><div class="gel-layout__item gel-1/3@s">
-                               <div class="gel-c-grid-demo-item"></div>
-                           </div>
-                        </div>
-                    </div>
-                </div>
-                <p class="gel-c-grid-demo__summary gel-brevier">Applied at large (900px) devices and above.</p>
+            <div class="gel-layout gs-u-mt+">
+              <div class="gel-layout__item">
+                <p class="gel-pica gs-u-mb">33.333% (Thirds)</p>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/3">
+                <div class="gel-c-grid-demo-item"></div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/3">
+                <div class="gel-c-grid-demo-item"></div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/3">
+                <div class="gel-c-grid-demo-item"></div>
+              </div>
             </div>
 
-            <div class="gel-c-grid-demo-section">
-                <h2 class="gel-double-pica-bold">Equal Height</h2>
-
-                <div class="gel-layout gel-layout--equal gs-u-mt+">
-                    <div class="gel-layout__item gel-1/2">
-                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--auto"></div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/2">
-                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--large"></div>
-                    </div>
-                </div>
-                <p class="gel-c-grid-demo__summary gel-brevier">Applied with the class: <code>gel-layout--equal</code>. This option only works for browsers which support <code>flexbox</code></p>
+            <div class="gel-layout gs-u-mt+">
+              <div class="gel-layout__item">
+                <p class="gel-pica gs-u-mb">25% (Quarters)</p>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/4">
+                <div class="gel-c-grid-demo-item"></div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/4">
+                <div class="gel-c-grid-demo-item"></div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/4">
+                <div class="gel-c-grid-demo-item"></div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/4">
+                <div class="gel-c-grid-demo-item"></div>
+              </div>
             </div>
 
-            <div class="gel-c-grid-demo-section">
-                <h2 class="gel-double-pica-bold">Horizontal Alignment</h2>
-
-                <div class="gel-layout gs-u-mt+">
-                    <div class="gel-layout__item gel-1/2">
-                        <p class="gel-pica gs-u-mb-">Left</p>
-                        <div class="gel-c-grid-demo-item"></div>
-                    </div>
-                </div>
-
-                <div class="gel-layout gel-layout--center gs-u-mt+">
-                    <div class="gel-layout__item gel-1/2">
-                        <p class="gel-pica gs-u-mb-">Centre</p>
-                        <div class="gel-c-grid-demo-item"></div>
-                        <p class="gel-c-grid-demo__summary gel-brevier">Applied with the class: <code>gel-layout--center</code></p>
-                    </div>
-                </div>
-
-                <div class="gel-layout gel-layout--right gs-u-mt+">
-                    <div class="gel-layout__item gel-1/2">
-                        <p class="gel-pica gs-u-mb-">Right</p>
-                        <div class="gel-c-grid-demo-item"></div>
-                        <p class="gel-c-grid-demo__summary gel-brevier">Applied with the class: <code>gel-layout--right</code></p>
-                    </div>
-                </div>
+            <div class="gel-layout gs-u-mt+">
+              <div class="gel-layout__item">
+                <p class="gel-pica gs-u-mb">20% (Fifths)</p>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/5">
+                <div class="gel-c-grid-demo-item"></div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/5">
+                <div class="gel-c-grid-demo-item"></div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/5">
+                <div class="gel-c-grid-demo-item"></div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/5">
+                <div class="gel-c-grid-demo-item"></div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/5">
+                <div class="gel-c-grid-demo-item"></div>
+              </div>
             </div>
 
-            <div class="gel-c-grid-demo-section">
-                <h2 class="gel-double-pica-bold">Top Alignment</h2>
+            <div class="gel-layout gs-u-mt+">
+              <div class="gel-layout__item">
+                <p class="gel-pica gs-u-mb">12.5% (Eighths)</p>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/8">
+                <div class="gel-c-grid-demo-item"></div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/8">
+                <div class="gel-c-grid-demo-item"></div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/8">
+                <div class="gel-c-grid-demo-item"></div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/8">
+                <div class="gel-c-grid-demo-item"></div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/8">
+                <div class="gel-c-grid-demo-item"></div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/8">
+                <div class="gel-c-grid-demo-item"></div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/8">
+                <div class="gel-c-grid-demo-item"></div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/8">
+                <div class="gel-c-grid-demo-item"></div>
+              </div>
+            </div>
+          </div>
 
-                <div class="gel-layout gs-u-mt+">
-                    <div class="gel-layout__item gel-1/3">
-                        <div class="gel-c-grid-demo-item"></div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/3">
-                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--large"></div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/3">
-                        <div class="gel-c-grid-demo-item"></div>
-                    </div>
+          <div class="gel-c-grid-demo-section">
+            <h2 class="gel-double-pica-bold">Example grid combinations</h2>
+
+            <div class="gel-layout gs-u-mt+">
+              <div class="gel-layout__item">
+                <p class="gel-pica gs-u-mb">Quarter / Three Quarters</p>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/4@xs">
+                <div class="gel-c-grid-demo-item"></div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-3/4@xs">
+                <div class="gel-c-grid-demo-item"></div>
+              </div>
+            </div>
+            <p class="gel-c-grid-demo__summary gel-brevier">
+              Applied at extra small (240px) devices and above.
+            </p>
+
+            <div class="gel-layout gs-u-mt+">
+              <div class="gel-layout__item">
+                <p class="gel-pica gs-u-mb">Half / Quarter / Two Eighths</p>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/2@s">
+                <div class="gel-c-grid-demo-item"></div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/4@s">
+                <div class="gel-c-grid-demo-item"></div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/8@s">
+                <div class="gel-c-grid-demo-item"></div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/8@s">
+                <div class="gel-c-grid-demo-item"></div>
+              </div>
+            </div>
+            <p class="gel-c-grid-demo__summary gel-brevier">
+              Applied at small (400px) devices and above.
+            </p>
+
+            <div class="gel-layout gs-u-mt+">
+              <div class="gel-layout__item">
+                <p class="gel-pica gs-u-mb">Two Thirds / Third</p>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-2/3@m">
+                <div class="gel-c-grid-demo-item"></div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/3@m">
+                <div class="gel-c-grid-demo-item"></div>
+              </div>
+            </div>
+            <p class="gel-c-grid-demo__summary gel-brevier">
+              Applied at medium (600px) devices and above.
+            </p>
+
+            <div class="gel-layout gs-u-mt+">
+              <div class="gel-layout__item">
+                <p class="gel-pica gs-u-mb">Half / Three Sixths</p>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/2@l">
+                <div class="gel-c-grid-demo-item"></div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/2@l">
+                <div class="gel-layout gs-u-mt+ gs-u-mt0@l">
+                  <div class="gel-layout__item gel-1/3@s">
+                    <div class="gel-c-grid-demo-item"></div>
+                  </div>
+                  <!--
+                        -->
+                  <div class="gel-layout__item gel-1/3@s">
+                    <div class="gel-c-grid-demo-item"></div>
+                  </div>
+                  <!--
+                        -->
+                  <div class="gel-layout__item gel-1/3@s">
+                    <div class="gel-c-grid-demo-item"></div>
+                  </div>
                 </div>
+              </div>
+            </div>
+            <p class="gel-c-grid-demo__summary gel-brevier">
+              Applied at large (900px) devices and above.
+            </p>
+          </div>
+
+          <div class="gel-c-grid-demo-section">
+            <h2 class="gel-double-pica-bold">Equal Height</h2>
+
+            <div class="gel-layout gel-layout--equal gs-u-mt+">
+              <div class="gel-layout__item gel-1/2">
+                <div class="gel-c-grid-demo-item gel-c-grid-demo-item--auto"></div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/2">
+                <div class="gel-c-grid-demo-item gel-c-grid-demo-item--large"></div>
+              </div>
+            </div>
+            <p class="gel-c-grid-demo__summary gel-brevier">
+              Applied with the class: <code>gel-layout--equal</code>. This option only works for
+              browsers which support <code>flexbox</code>
+            </p>
+          </div>
+
+          <div class="gel-c-grid-demo-section">
+            <h2 class="gel-double-pica-bold">Horizontal Alignment</h2>
+
+            <div class="gel-layout gs-u-mt+">
+              <div class="gel-layout__item gel-1/2">
+                <p class="gel-pica gs-u-mb-">Left</p>
+                <div class="gel-c-grid-demo-item"></div>
+              </div>
             </div>
 
-            <div class="gel-c-grid-demo-section">
-                <h2 class="gel-double-pica-bold">Middle Alignment</h2>
-
-                <div class="gel-layout gel-layout--middle gs-u-mt+">
-                    <div class="gel-layout__item gel-1/3">
-                        <div class="gel-c-grid-demo-item"></div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/3">
-                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--large"></div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/3">
-                        <div class="gel-c-grid-demo-item"></div>
-                    </div>
-                </div>
-                <p class="gel-c-grid-demo__summary gel-brevier">Applied with the class: <code>gel-layout--middle</code></p>
+            <div class="gel-layout gel-layout--center gs-u-mt+">
+              <div class="gel-layout__item gel-1/2">
+                <p class="gel-pica gs-u-mb-">Centre</p>
+                <div class="gel-c-grid-demo-item"></div>
+                <p class="gel-c-grid-demo__summary gel-brevier">
+                  Applied with the class: <code>gel-layout--center</code>
+                </p>
+              </div>
             </div>
 
-            <div class="gel-c-grid-demo-section">
-                <h2 class="gel-double-pica-bold">Bottom Alignment</h2>
-
-                <div class="gel-layout gel-layout--bottom gs-u-mt+">
-                    <div class="gel-layout__item gel-1/3">
-                        <div class="gel-c-grid-demo-item"></div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/3">
-                        <div class="gel-c-grid-demo-item gel-c-grid-demo-item--large"></div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/3">
-                        <div class="gel-c-grid-demo-item"></div>
-                    </div>
-                </div>
-                <p class="gel-c-grid-demo__summary gel-brevier">Applied with the class: <code>gel-layout--bottom</code></p>
+            <div class="gel-layout gel-layout--right gs-u-mt+">
+              <div class="gel-layout__item gel-1/2">
+                <p class="gel-pica gs-u-mb-">Right</p>
+                <div class="gel-c-grid-demo-item"></div>
+                <p class="gel-c-grid-demo__summary gel-brevier">
+                  Applied with the class: <code>gel-layout--right</code>
+                </p>
+              </div>
             </div>
+          </div>
 
-            <div class="gel-c-grid-demo-section">
-                <h2 class="gel-double-pica-bold">Reversed</h2>
+          <div class="gel-c-grid-demo-section">
+            <h2 class="gel-double-pica-bold">Top Alignment</h2>
 
-                <div class="gel-layout gel-layout--rev gs-u-mt+">
-                    <div class="gel-layout__item gel-1/4">
-                        <p class="gel-pica gs-u-mb-">1</p>
-                        <div class="gel-c-grid-demo-item"></div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/4">
-                        <p class="gel-pica gs-u-mb-">2</p>
-                        <div class="gel-c-grid-demo-item"></div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/4">
-                        <p class="gel-pica gs-u-mb-">3</p>
-                        <div class="gel-c-grid-demo-item"></div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/4">
-                        <p class="gel-pica gs-u-mb-">4</p>
-                        <div class="gel-c-grid-demo-item"></div>
-                    </div>
-                </div>
-                <p class="gel-c-grid-demo__summary gel-brevier">Applied with the class: <code>gel-layout--rev</code></p>
+            <div class="gel-layout gs-u-mt+">
+              <div class="gel-layout__item gel-1/3">
+                <div class="gel-c-grid-demo-item"></div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/3">
+                <div class="gel-c-grid-demo-item gel-c-grid-demo-item--large"></div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/3">
+                <div class="gel-c-grid-demo-item"></div>
+              </div>
             </div>
+          </div>
 
-            <div class="gel-c-grid-demo-section">
-                <h2 class="gel-double-pica-bold">Flush</h2>
+          <div class="gel-c-grid-demo-section">
+            <h2 class="gel-double-pica-bold">Middle Alignment</h2>
 
-                <div class="gel-layout gel-layout--flush gs-u-mt+">
-                    <div class="gel-layout__item gel-1/4">
-                        <p class="gel-pica gs-u-mb-">1</p>
-                        <div class="gel-c-grid-demo-item"></div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/4">
-                        <p class="gel-pica gs-u-mb-">2</p>
-                        <div class="gel-c-grid-demo-item"></div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/4">
-                        <p class="gel-pica gs-u-mb-">3</p>
-                        <div class="gel-c-grid-demo-item"></div>
-                    </div><!--
-                 --><div class="gel-layout__item gel-1/4">
-                        <p class="gel-pica gs-u-mb-">4</p>
-                        <div class="gel-c-grid-demo-item"></div>
-                    </div>
-                </div>
-                <p class="gel-c-grid-demo__summary gel-brevier">Applied with the class: <code>gel-layout--flush</code></p>
+            <div class="gel-layout gel-layout--middle gs-u-mt+">
+              <div class="gel-layout__item gel-1/3">
+                <div class="gel-c-grid-demo-item"></div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/3">
+                <div class="gel-c-grid-demo-item gel-c-grid-demo-item--large"></div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/3">
+                <div class="gel-c-grid-demo-item"></div>
+              </div>
             </div>
+            <p class="gel-c-grid-demo__summary gel-brevier">
+              Applied with the class: <code>gel-layout--middle</code>
+            </p>
+          </div>
 
-            <div class="gel-c-grid-demo-section">
-                <h2 class="gel-double-pica-bold">Fit</h2>
+          <div class="gel-c-grid-demo-section">
+            <h2 class="gel-double-pica-bold">Bottom Alignment</h2>
 
-                <div class="gel-layout gel-layout--fit gs-u-mt+">
-                    <div class="gel-layout__item">
-                        <p class="gel-pica gs-u-mb-">1</p>
-                        <div class="gel-c-grid-demo-item"></div>
-                    </div><!--
-                 --><div class="gel-layout__item">
-                        <p class="gel-pica gs-u-mb-">2</p>
-                        <div class="gel-c-grid-demo-item"></div>
-                    </div><!--
-                 --><div class="gel-layout__item">
-                        <p class="gel-pica gs-u-mb-">3</p>
-                        <div class="gel-c-grid-demo-item"></div>
-                    </div><!--
-                 --><div class="gel-layout__item">
-                        <p class="gel-pica gs-u-mb-">4</p>
-                        <div class="gel-c-grid-demo-item"></div>
-                    </div>
-                </div>
-                <div class="gel-layout gel-layout--fit gs-u-mt+">
-                    <div class="gel-layout__item">
-                        <p class="gel-pica gs-u-mb-">1</p>
-                        <div class="gel-c-grid-demo-item"></div>
-                    </div><!--
-                 --><div class="gel-layout__item">
-                        <p class="gel-pica gs-u-mb-">2</p>
-                        <div class="gel-c-grid-demo-item"></div>
-                    </div>
-                </div>
-                <p class="gel-c-grid-demo__summary gel-brevier">Applied with the class: <code>gel-layout--fit</code>. This option only works for browsers which support <code>flexbox</code></p>
+            <div class="gel-layout gel-layout--bottom gs-u-mt+">
+              <div class="gel-layout__item gel-1/3">
+                <div class="gel-c-grid-demo-item"></div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/3">
+                <div class="gel-c-grid-demo-item gel-c-grid-demo-item--large"></div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/3">
+                <div class="gel-c-grid-demo-item"></div>
+              </div>
             </div>
+            <p class="gel-c-grid-demo__summary gel-brevier">
+              Applied with the class: <code>gel-layout--bottom</code>
+            </p>
+          </div>
+
+          <div class="gel-c-grid-demo-section">
+            <h2 class="gel-double-pica-bold">Reversed</h2>
+
+            <div class="gel-layout gel-layout--rev gs-u-mt+">
+              <div class="gel-layout__item gel-1/4">
+                <p class="gel-pica gs-u-mb-">1</p>
+                <div class="gel-c-grid-demo-item"></div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/4">
+                <p class="gel-pica gs-u-mb-">2</p>
+                <div class="gel-c-grid-demo-item"></div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/4">
+                <p class="gel-pica gs-u-mb-">3</p>
+                <div class="gel-c-grid-demo-item"></div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/4">
+                <p class="gel-pica gs-u-mb-">4</p>
+                <div class="gel-c-grid-demo-item"></div>
+              </div>
+            </div>
+            <p class="gel-c-grid-demo__summary gel-brevier">
+              Applied with the class: <code>gel-layout--rev</code>
+            </p>
+          </div>
+
+          <div class="gel-c-grid-demo-section">
+            <h2 class="gel-double-pica-bold">Flush</h2>
+
+            <div class="gel-layout gel-layout--flush gs-u-mt+">
+              <div class="gel-layout__item gel-1/4">
+                <p class="gel-pica gs-u-mb-">1</p>
+                <div class="gel-c-grid-demo-item"></div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/4">
+                <p class="gel-pica gs-u-mb-">2</p>
+                <div class="gel-c-grid-demo-item"></div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/4">
+                <p class="gel-pica gs-u-mb-">3</p>
+                <div class="gel-c-grid-demo-item"></div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item gel-1/4">
+                <p class="gel-pica gs-u-mb-">4</p>
+                <div class="gel-c-grid-demo-item"></div>
+              </div>
+            </div>
+            <p class="gel-c-grid-demo__summary gel-brevier">
+              Applied with the class: <code>gel-layout--flush</code>
+            </p>
+          </div>
+
+          <div class="gel-c-grid-demo-section">
+            <h2 class="gel-double-pica-bold">Fit</h2>
+
+            <div class="gel-layout gel-layout--fit gs-u-mt+">
+              <div class="gel-layout__item">
+                <p class="gel-pica gs-u-mb-">1</p>
+                <div class="gel-c-grid-demo-item"></div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item">
+                <p class="gel-pica gs-u-mb-">2</p>
+                <div class="gel-c-grid-demo-item"></div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item">
+                <p class="gel-pica gs-u-mb-">3</p>
+                <div class="gel-c-grid-demo-item"></div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item">
+                <p class="gel-pica gs-u-mb-">4</p>
+                <div class="gel-c-grid-demo-item"></div>
+              </div>
+            </div>
+            <div class="gel-layout gel-layout--fit gs-u-mt+">
+              <div class="gel-layout__item">
+                <p class="gel-pica gs-u-mb-">1</p>
+                <div class="gel-c-grid-demo-item"></div>
+              </div>
+              <!--
+                 -->
+              <div class="gel-layout__item">
+                <p class="gel-pica gs-u-mb-">2</p>
+                <div class="gel-c-grid-demo-item"></div>
+              </div>
+            </div>
+            <p class="gel-c-grid-demo__summary gel-brevier">
+              Applied with the class: <code>gel-layout--fit</code>. This option only works for
+              browsers which support <code>flexbox</code>
+            </p>
+          </div>
         </div>
-    </main>
-</div>
+      </main>
+    </div>
 
-<script>
-function overlayTextToggle() {
-    var overlayToggle = document.getElementById('overlay-toggle');
-    overlayToggle.innerHTML === 'Toggle Grid Overlay On' ?
-        overlayToggle.innerHTML = 'Toggle Grid Overlay Off' : overlayToggle.innerHTML = 'Toggle Grid Overlay On';
-}
+    <script>
+      function overlayTextToggle() {
+        var overlayToggle = document.getElementById('overlay-toggle');
+        overlayToggle.innerHTML === 'Toggle Grid Overlay On'
+          ? (overlayToggle.innerHTML = 'Toggle Grid Overlay Off')
+          : (overlayToggle.innerHTML = 'Toggle Grid Overlay On');
+      }
 
-function gridOverlay() {
-    if (document.getElementsByClassName("gel-grid-overlay").length) {
-        document.getElementsByClassName("gel-grid-overlay")[0].remove()
-    }
-    var e = "<div class=\"gel-grid-overlay__grid\"><div class=\"gel-grid-overlay__margin\" style=\"left: 0;\"></div>";
-    for (i = 0; i < 12; i++) {
-        e += "<div class=\"gel-grid-overlay__column\"><div class=\"gel-grid-overlay__column-fill\"></div></div>"
-    }
-    e += "<div class=\"gel-grid-overlay__margin\" style=\"right: 0;\"></div>";
-    e += "</div>";
-    var t = document.createElement("div");
-    t.className = "gel-grid-overlay";
-    t.innerHTML = e;
-    var n = document.createElement("style");
-    n.innerHTML = ".gel-grid-overlay * {-moz-box-sizing: border-box; -webkit-box-sizing: border-box; box-sizing: border-box;);}.gel-grid-overlay {z-index: 2147483647; position: fixed; height: 100%; width: 100%; left: 0; top: 0;}.gel-grid-overlay__grid {position: relative; width: 100%; height: 100%; max-width: 1008px; margin: 0 auto; padding: 0 4px;}.gel-grid-overlay__column {display: inline-block; height: 100%; width: 8.33333%; padding: 0 4px;}.gel-grid-overlay__column-fill {background: rgba(255,0,0,0.1); height: 100%;}.gel-grid-overlay__margin {display: inline-block; height: 100%; width: 8px; position: absolute; top: 0; background: rgba(0,255,0,0.1);}@media screen and (min-width: 400px) {.gel-grid-overlay__grid {padding: 0 12px;}.gel-grid-overlay__margin {width: 16px;}@media screen and (min-width: 600px) {.gel-grid-overlay__grid {padding: 0 8px;}.gel-grid-overlay__column {padding: 0 8px;}}@media screen and (min-width: 1280px) {.gel-grid-overlay__grid {max-width: 1280px;}}";
-    document.getElementsByTagName("head")[0].appendChild(n);
-    document.getElementsByTagName("body")[0].appendChild(t);
-    t.addEventListener("click", function() {
-        document.getElementsByClassName("gel-grid-overlay")[0].remove();
-        overlayTextToggle();
-    });
-}
+      function gridOverlay() {
+        if (document.getElementsByClassName('gel-grid-overlay').length) {
+          document.getElementsByClassName('gel-grid-overlay')[0].remove();
+        }
+        var e =
+          '<div class="gel-grid-overlay__grid"><div class="gel-grid-overlay__margin" style="left: 0;"></div>';
+        for (i = 0; i < 12; i++) {
+          e +=
+            '<div class="gel-grid-overlay__column"><div class="gel-grid-overlay__column-fill"></div></div>';
+        }
+        e += '<div class="gel-grid-overlay__margin" style="right: 0;"></div>';
+        e += '</div>';
+        var t = document.createElement('div');
+        t.className = 'gel-grid-overlay';
+        t.innerHTML = e;
+        var n = document.createElement('style');
+        n.innerHTML =
+          '.gel-grid-overlay * {-moz-box-sizing: border-box; -webkit-box-sizing: border-box; box-sizing: border-box;);}.gel-grid-overlay {z-index: 2147483647; position: fixed; height: 100%; width: 100%; left: 0; top: 0;}.gel-grid-overlay__grid {position: relative; width: 100%; height: 100%; max-width: 1008px; margin: 0 auto; padding: 0 4px;}.gel-grid-overlay__column {display: inline-block; height: 100%; width: 8.33333%; padding: 0 4px;}.gel-grid-overlay__column-fill {background: rgba(255,0,0,0.1); height: 100%;}.gel-grid-overlay__margin {display: inline-block; height: 100%; width: 8px; position: absolute; top: 0; background: rgba(0,255,0,0.1);}@media screen and (min-width: 400px) {.gel-grid-overlay__grid {padding: 0 12px;}.gel-grid-overlay__margin {width: 16px;}@media screen and (min-width: 600px) {.gel-grid-overlay__grid {padding: 0 8px;}.gel-grid-overlay__column {padding: 0 8px;}}@media screen and (min-width: 1280px) {.gel-grid-overlay__grid {max-width: 1280px;}}';
+        document.getElementsByTagName('head')[0].appendChild(n);
+        document.getElementsByTagName('body')[0].appendChild(t);
+        t.addEventListener('click', function () {
+          document.getElementsByClassName('gel-grid-overlay')[0].remove();
+          overlayTextToggle();
+        });
+      }
 
-function toggleStyles() {
-    var html = document.querySelector('html');
-    var stylesheet = document.getElementById('stylesheet');
-    var rtlToggle = document.getElementById('rtl-toggle');
+      function toggleStyles() {
+        var html = document.querySelector('html');
+        var stylesheet = document.getElementById('stylesheet');
+        var rtlToggle = document.getElementById('rtl-toggle');
 
-    rtlToggle.innerHTML = (rtlToggle.innerHTML === 'Toggle RTL On') ?
-        'Toggle RTL Off' : 'Toggle RTL On';
+        rtlToggle.innerHTML =
+          rtlToggle.innerHTML === 'Toggle RTL On' ? 'Toggle RTL Off' : 'Toggle RTL On';
 
-    if (stylesheet.getAttribute('href').indexOf('-rtl') > -1) {
-        if (GEL.mustard) {
+        if (stylesheet.getAttribute('href').indexOf('-rtl') > -1) {
+          if (GEL.mustard) {
             stylesheet.setAttribute('href', 'assets/css/gel-demo-enhanced.css');
-        } else {
+          } else {
             stylesheet.setAttribute('href', 'assets/css/gel-demo-base.css');
-        }
+          }
 
-        html.setAttribute('dir', 'ltr');
-    } else {
-        if (GEL.mustard) {
-            stylesheet.setAttribute('href', 'assets/css/gel-demo-enhanced-rtl.css');
+          html.setAttribute('dir', 'ltr');
         } else {
+          if (GEL.mustard) {
+            stylesheet.setAttribute('href', 'assets/css/gel-demo-enhanced-rtl.css');
+          } else {
             stylesheet.setAttribute('href', 'assets/css/gel-demo-base-rtl.css');
+          }
+
+          html.setAttribute('dir', 'rtl');
         }
+      }
 
-        html.setAttribute('dir', 'rtl');
-    }
-}
+      (function () {
+        var overlayToggle = document.getElementById('overlay-toggle');
+        overlayToggle.addEventListener('click', function () {
+          gridOverlay();
+          overlayTextToggle();
+        });
 
-(function() {
-    var overlayToggle = document.getElementById('overlay-toggle');
-    overlayToggle.addEventListener('click', function() {
-        gridOverlay();
-        overlayTextToggle();
-    });
-
-    var rtlToggle = document.getElementById('rtl-toggle');
-    rtlToggle.addEventListener('click', function() {
-        toggleStyles();
-    });
-}());
-</script>
-</body>
+        var rtlToggle = document.getElementById('rtl-toggle');
+        rtlToggle.addEventListener('click', function () {
+          toggleStyles();
+        });
+      })();
+    </script>
+  </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
     "build": "npm run build:compressed && npm run build:expanded",
     "build:compressed": "sass --load-path=node_modules/ --style=compressed --no-source-map src/gel-grid.scss dist/gel-grid.min.css",
     "build:expanded": "sass --load-path=node_modules/ --style=expanded --no-source-map src/gel-grid.scss dist/gel-grid.css",
-    "prettier": "prettier --write '{lib/**/*,src/**/*,test/**/*,*}.{js,json,mjs,scss}'",
-    "pretest": "npm run prettier",
-    "test": "jest"
+    "jest": "jest",
+    "prettier": "prettier . '!**/*.md' --write",
+    "test": "npm run prettier && npm run jest"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build:compressed": "sass --load-path=node_modules/ --style=compressed --no-source-map src/gel-grid.scss dist/gel-grid.min.css",
     "build:expanded": "sass --load-path=node_modules/ --style=expanded --no-source-map src/gel-grid.scss dist/gel-grid.css",
     "jest": "jest",
-    "prettier": "prettier . '!**/*.md' --write",
+    "prettier": "prettier . '!**/*.md' '!bookmarklets/*.js' '!**/*.min.*' --write",
     "test": "npm run prettier && npm run jest"
   },
   "repository": {


### PR DESCRIPTION
## Description
Using `npm config set ignore-scripts true` means that any scripts with `pre...` and `post...` will no longer run. Whilst this may improve the security around npm scripts it does mean that the workflows need to be adjusted - which is what this PR does.

At the same time the package.json prettier command has been updated to ensure more files are formatted consistently.